### PR TITLE
fix: Content Tonie Entitäten, aktiver Tonie und Gesamtanzahl

### DIFF
--- a/custom_components/toniebox/binary_sensor.py
+++ b/custom_components/toniebox/binary_sensor.py
@@ -49,14 +49,6 @@ async def async_setup_entry(
                 ContentTonieTranscodingBinarySensor(coordinator, hh_id, ct_id),
             ]
 
-    for hh_id, hh in coordinator.data.get("households", {}).items():
-        for ct_id in hh.get("contenttonies", {}):
-            entities += [
-                ContentTonieActiveBinarySensor(coordinator, hh_id, ct_id),
-                ContentTonieLockBinarySensor(coordinator, hh_id, ct_id),
-                ContentTonieTranscodingBinarySensor(coordinator, hh_id, ct_id),
-            ]
-
     async_add_entities(entities)
 
 

--- a/custom_components/toniebox/button.py
+++ b/custom_components/toniebox/button.py
@@ -10,7 +10,6 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .content_tonie import ContentTonieTuneRemoveButton
-from .content_tonie import ContentTonieTuneRemoveButton
 from .device_info import creative_tonie_device_info, toniebox_device_info, household_device_info
 
 
@@ -50,10 +49,6 @@ async def async_setup_entry(
             entities.append(TonieboxResetButton(coordinator, hh_id, tb_id))
 
     # ── Content Tonie buttons ─────────────────────────────────────────────────
-    for hh_id, hh in coordinator.data.get("households", {}).items():
-        for ct_id in hh.get("contenttonies", {}):
-            entities.append(ContentTonieTuneRemoveButton(coordinator, hh_id, ct_id))
-
     for hh_id, hh in coordinator.data.get("households", {}).items():
         for ct_id in hh.get("contenttonies", {}):
             entities.append(ContentTonieTuneRemoveButton(coordinator, hh_id, ct_id))

--- a/custom_components/toniebox/content_tonie.py
+++ b/custom_components/toniebox/content_tonie.py
@@ -108,11 +108,24 @@ class ContentTonieCurrentBoxSensor(_CTBase, SensorEntity):
 
     @property
     def native_value(self) -> str | None:
-        # Try to resolve toniebox ID → name from coordinator
-        box_id = self._ct.get("toniebox_id") or self._ct.get("tonieboxId")
+        hh = self.coordinator.data.get("households", {}).get(self._hh_id, {})
+        # Prefer direct field from API
+        box_id = self._ct.get("toniebox_id")
+        if not box_id:
+            # Fall back: find which toniebox has this content tonie placed on it
+            for tb_id, tb in hh.get("tonieboxes", {}).items():
+                placement = tb.get("placement", {})
+                if isinstance(placement, dict):
+                    placed_id = (
+                        (placement.get("tonie") or {}).get("id")
+                        or placement.get("tonieId")
+                        or placement.get("tonie_id")
+                    )
+                    if placed_id == self._ct_id:
+                        box_id = tb_id
+                        break
         if not box_id:
             return None
-        hh = self.coordinator.data.get("households", {}).get(self._hh_id, {})
         box = hh.get("tonieboxes", {}).get(box_id, {})
         return box.get("name") or box_id
 
@@ -204,14 +217,15 @@ class ContentTonieActiveBinarySensor(_CTBase, BinarySensorEntity):
 
     @property
     def is_on(self) -> bool:
-        # A Content Tonie is "active" if any Toniebox in this household is currently
-        # playing it (placement matches this tonie's ID)
+        # A Content Tonie is "active" if any Toniebox in this household has it placed
         hh = self.coordinator.data.get("households", {}).get(self._hh_id, {})
         for tb in hh.get("tonieboxes", {}).values():
             placement = tb.get("placement", {})
             if isinstance(placement, dict):
+                # API returns placement = {"tonie": {"id": "...", ...}}
                 placed_id = (
-                    placement.get("tonieId")
+                    (placement.get("tonie") or {}).get("id")
+                    or placement.get("tonieId")
                     or placement.get("tonie_id")
                     or placement.get("id")
                 )

--- a/custom_components/toniebox/media_player.py
+++ b/custom_components/toniebox/media_player.py
@@ -171,15 +171,15 @@ class TonieboxPlayer(CoordinatorEntity, MediaPlayerEntity):
         # Show chapter title from playback info if available
         info = self._tb.get("playback_info", {})
         chapter_title = info.get("chapterTitle") or info.get("chapter_title")
-        tonie_name = tonie.get("name", "Tonie aufgelegt")
+        tonie_name = tonie.get("name") or tonie.get("id", "Tonie aufgelegt")
         if chapter_title:
             return f"{tonie_name} – {chapter_title}"
         return tonie_name
 
     @property
     def media_image_url(self) -> str | None:
-        tonie = self._tb.get("placement", {}).get("tonie", {})
-        return tonie.get("image_url") if tonie else None
+        tonie = self._tb.get("placement", {}).get("tonie") or {}
+        return tonie.get("imageUrl") or tonie.get("image_url")
 
     @property
     def media_image_remotely_accessible(self) -> bool:

--- a/custom_components/toniebox/select.py
+++ b/custom_components/toniebox/select.py
@@ -12,7 +12,6 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, SORT_OPTIONS, SORT_BY_TITLE
 from .content_tonie import ContentTonieLanguageSelect
-from .content_tonie import ContentTonieLanguageSelect
 from .device_info import creative_tonie_device_info, toniebox_device_info
 
 _LOGGER = logging.getLogger(__name__)
@@ -112,10 +111,6 @@ async def async_setup_entry(
             entities.append(TonieSortSelect(coordinator, hh_id, t_id))
 
     # ── Content Tonie selects ─────────────────────────────────────────────────
-    for hh_id, hh in coordinator.data.get("households", {}).items():
-        for ct_id in hh.get("contenttonies", {}):
-            entities.append(ContentTonieLanguageSelect(coordinator, hh_id, ct_id))
-
     for hh_id, hh in coordinator.data.get("households", {}).items():
         for ct_id in hh.get("contenttonies", {}):
             entities.append(ContentTonieLanguageSelect(coordinator, hh_id, ct_id))

--- a/custom_components/toniebox/sensor.py
+++ b/custom_components/toniebox/sensor.py
@@ -19,12 +19,6 @@ from .device_info import (
     toniebox_device_info,
     creative_tonie_device_info,
 )
-from .content_tonie import (
-    ContentTonieCurrentBoxSensor,
-    ContentTonieChapterCountSensor,
-    ContentTonieDurationSensor,
-    ContentTonieSalesSensor,
-)
 
 
 async def async_setup_entry(
@@ -78,16 +72,6 @@ async def async_setup_entry(
             ]
 
         # ── Content Tonie sensors (one device per figurine) ───────────────────
-        for ct_id in hh.get("contenttonies", {}):
-            entities += [
-                ContentTonieCurrentBoxSensor(coordinator, hh_id, ct_id),
-                ContentTonieChapterCountSensor(coordinator, hh_id, ct_id),
-                ContentTonieDurationSensor(coordinator, hh_id, ct_id),
-                ContentTonieSalesSensor(coordinator, hh_id, ct_id),
-            ]
-
-    # Content Tonie sensors — one device per figurine
-    for hh_id, hh in coordinator.data.get("households", {}).items():
         for ct_id in hh.get("contenttonies", {}):
             entities += [
                 ContentTonieCurrentBoxSensor(coordinator, hh_id, ct_id),

--- a/custom_components/toniebox/switch.py
+++ b/custom_components/toniebox/switch.py
@@ -11,7 +11,6 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .content_tonie import ContentTonieLockSwitch
-from .content_tonie import ContentTonieLockSwitch
 from .device_info import toniebox_device_info, creative_tonie_device_info
 
 _LOGGER = logging.getLogger(__name__)
@@ -45,10 +44,6 @@ async def async_setup_entry(
             ]
 
     # ── Content Tonie switches ────────────────────────────────────────────────
-    for hh_id, hh in coordinator.data.get("households", {}).items():
-        for ct_id in hh.get("contenttonies", {}):
-            entities.append(ContentTonieLockSwitch(coordinator, hh_id, ct_id))
-
     for hh_id, hh in coordinator.data.get("households", {}).items():
         for ct_id in hh.get("contenttonies", {}):
             entities.append(ContentTonieLockSwitch(coordinator, hh_id, ct_id))


### PR DESCRIPTION
- Doppelte Entity-Registrierung in sensor/binary_sensor/switch/button/select entfernt
  → HA warf "duplicate unique_id"-Fehler, wodurch alle Content Tonie Entitäten fehlschlugen
- Doppelte Imports bereinigt (switch, button, select, sensor)
- ContentTonieActiveBinarySensor: placement-Struktur korrigiert
  → API liefert placement.tonie.id, nicht placement.tonieId direkt
- ContentTonieCurrentBoxSensor: Fallback-Suche über Toniebox-Placement ergänzt
  → funktioniert auch wenn API kein tonieboxId am Content Tonie mitliefert
- TonieboxPlayer.media_image_url: imageUrl (camelCase) korrekt ausgelesen
- TonieboxPlayer.media_title: robusterer Tonie-Name-Fallback

https://claude.ai/code/session_01U4po1bTGjVBnnybueveqBQ