### PR TITLE
fix: Content Tonie Anzahl 0 und fehlende Entitäten

### DIFF
--- a/custom_components/toniebox/__init__.py
+++ b/custom_components/toniebox/__init__.py
@@ -471,12 +471,24 @@ class TonieboxDataUpdateCoordinator(DataUpdateCoordinator):
             # Content Tonies (purchased/assigned figurines)
             try:
                 content_tonies = await self.client.get_content_tonies(hh_id)
-                _LOGGER.debug(
+                _LOGGER.info(
                     "contenttonies for %s: got %d items", hh_id, len(content_tonies)
                 )
                 for ct in content_tonies:
-                    ct_id = ct.get("id", "")
+                    # Try multiple possible ID field names
+                    ct_id = (
+                        ct.get("id")
+                        or ct.get("uid")
+                        or ct.get("figureId")
+                        or ct.get("figurineId")
+                        or ct.get("entityId")
+                        or ""
+                    )
                     if not ct_id:
+                        _LOGGER.warning(
+                            "Skipping content tonie with no ID — available fields: %s",
+                            list(ct.keys()),
+                        )
                         continue
                     # Chapters normalisieren
                     raw_chapters = ct.get("chapters", [])

--- a/custom_components/toniebox/content_tonie.py
+++ b/custom_components/toniebox/content_tonie.py
@@ -24,51 +24,15 @@ from homeassistant.components.button import ButtonEntity
 from homeassistant.components.select import SelectEntity
 from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.core import callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
 from .device_info import content_tonie_device_info
 
 _LOGGER = logging.getLogger(__name__)
 
 # Languages supported by multi-language Content Tonies (same as Toniebox)
 _LANGUAGES = ["de", "en", "en-us", "fr"]
-
-
-# ── Setup ─────────────────────────────────────────────────────────────────────
-
-async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
-) -> None:
-    coordinator = hass.data[DOMAIN][entry.entry_id]
-    entities: list = []
-
-    for hh_id, hh in coordinator.data.get("households", {}).items():
-        for ct_id, ct in hh.get("contenttonies", {}).items():
-            # ── Sensors ──────────────────────────────────────────────────────
-            entities += [
-                ContentTonieCurrentBoxSensor(coordinator, hh_id, ct_id),
-                ContentTonieChapterCountSensor(coordinator, hh_id, ct_id),
-                ContentTonieDurationSensor(coordinator, hh_id, ct_id),
-                ContentTonieSalesSensor(coordinator, hh_id, ct_id),
-            ]
-            # ── Binary sensors ────────────────────────────────────────────────
-            entities += [
-                ContentTonieActiveBinarySensor(coordinator, hh_id, ct_id),
-                ContentTonieLockBinarySensor(coordinator, hh_id, ct_id),
-                ContentTonieTranscodingBinarySensor(coordinator, hh_id, ct_id),
-            ]
-            # ── Switch: lock ──────────────────────────────────────────────────
-            entities.append(ContentTonieLockSwitch(coordinator, hh_id, ct_id))
-            # ── Button: remove tune ───────────────────────────────────────────
-            entities.append(ContentTonieTuneRemoveButton(coordinator, hh_id, ct_id))
-            # ── Select: language (only shown if language field present) ───────
-            entities.append(ContentTonieLanguageSelect(coordinator, hh_id, ct_id))
-
-    async_add_entities(entities)
 
 
 # ── Base ──────────────────────────────────────────────────────────────────────

--- a/custom_components/toniebox/tonie_client.py
+++ b/custom_components/toniebox/tonie_client.py
@@ -562,12 +562,24 @@ class TonieCloudClient:
         if isinstance(data, list):
             return data
         if isinstance(data, dict):
-            # Try known wrapper keys — log actual keys if none match
-            for key in ("contenttonies", "data", "items", "results", "tonies"):
+            # Try known wrapper keys (both snake_case and camelCase)
+            for key in (
+                "contenttonies", "contentTonies", "content_tonies",
+                "data", "items", "results", "tonies", "tonie",
+                "figurines", "tonieFigurines",
+            ):
                 if key in data and isinstance(data[key], list):
                     return data[key]
-            _LOGGER.debug(
-                "get_content_tonies: unexpected response shape. "
+            # Fallback: return the first list value found
+            for key, val in data.items():
+                if isinstance(val, list):
+                    _LOGGER.warning(
+                        "get_content_tonies: unexpected response key '%s'. "
+                        "Top-level keys: %s", key, list(data.keys())
+                    )
+                    return val
+            _LOGGER.warning(
+                "get_content_tonies: response contains no list. "
                 "Top-level keys: %s", list(data.keys())
             )
         return []


### PR DESCRIPTION
- get_content_tonies: mehr mögliche Wrapper-Keys (camelCase, figurines etc.)
  sowie Fallback auf ersten Listen-Wert im Response-Dict;
  Debug-Log zu WARNING hochgestuft damit API-Fehler sichtbar sind
- _fetch_all: Content Tonie ID-Extraktion um alternative Felder erweitert
  (uid, figureId, figurineId, entityId) damit Objekte ohne "id"-Feld
  nicht mehr lautlos übersprungen werden; Count-Log von DEBUG auf INFO
- content_tonie.py: toten async_setup_entry und ungenutzte Imports entfernt
  (Funktion wurde nie von HA aufgerufen, Entity-Registrierung erfolgt
  korrekt über die Plattform-Dateien sensor/binary_sensor/switch/button/select)

https://claude.ai/code/session_01WmcsRK88L2mgJyf97uvqm1