### PR TITLE
feat: full English integration with German translation, bump to v3.2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <strong>Unofficial Home Assistant Integration for Toniebox / Tonie Cloud</strong><br/>
-  Vollständige Integration deiner Tonieboxen und Creative Tonies in Home Assistant.
+  <em>Inoffizielle Home Assistant Integration für Toniebox / Tonie Cloud</em>
 </p>
 
 <p align="center">
@@ -22,15 +22,412 @@
 ---
 
 > [!WARNING]
-> **Disclaimer — Bitte vor der Nutzung lesen**
+> **Disclaimer — Please read before use / Bitte vor der Nutzung lesen**
 >
-> Dieses Projekt steht in **keiner Verbindung zu Boxine GmbH** (Hersteller von Toniebox / tonies.de) und wird von diesen weder unterstützt noch empfohlen.
-> Es nutzt die offizielle Tonie Cloud REST API, die **sich jederzeit ohne Ankündigung ändern kann**.
-> Nutzung **auf eigene Gefahr**. Keine Garantie, kein Support durch Boxine.
+> This project has **no affiliation with Boxine GmbH** (manufacturer of Toniebox / tonies.de) and is neither supported nor endorsed by them.
+> It uses the official Tonie Cloud REST API, which **may change at any time without notice**.
+> Use **at your own risk**. No warranty, no support from Boxine.
 >
-> 🤖 Diese Integration wurde **vibecoded** — mit KI-Unterstützung ([Claude by Anthropic](https://anthropic.com)) entwickelt und gegen ein echtes Toniebox-Konto getestet.
+> *Dieses Projekt steht in **keiner Verbindung zu Boxine GmbH** und wird von diesen weder unterstützt noch empfohlen. Es nutzt die offizielle Tonie Cloud REST API, die **sich jederzeit ohne Ankündigung ändern kann**. Nutzung **auf eigene Gefahr**.*
+>
+> 🤖 This integration was **vibecoded** — developed with AI assistance ([Claude by Anthropic](https://anthropic.com)) and tested against a real Toniebox account.
 
 ---
+
+<!-- ENGLISH -->
+# 🇬🇧 English
+
+## Features
+
+- 🧸 Each **Creative Tonie** as its own device with media player, cover image and chapter list
+- 📻 Each **Toniebox** as its own device — shows the currently placed figure with name and cover
+- 📊 **Sensors** for chapter count, total duration, firmware version, online status, active box
+- 🔘 **Buttons** to sort (title / filename / date), clear and refresh
+- 🔴 **Binary Sensors** for transcoding, live mode, household lock, active figure
+- 🎛️ **Switches** for LED, chapter skipping, scrubbing, offline mode, household lock
+- 🌐 **Select entities** for language, LED level, tap direction, age mode
+- ⚙️ **13 Services** for automations: sort, clear, rename, apply tune, redeem voucher and more
+- 🌍 **Translations** for English, German, French, Spanish and Italian
+- 🔐 Keycloak OpenID Connect authentication — same credentials as the Toniebox app
+- 🛠️ Config Flow setup — **no YAML required**
+- 📦 HACS compatible
+
+---
+
+## Installation via HACS
+
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=git4sim&repository=HA-Toniebox&category=integration)
+
+> [!NOTE]
+> If the button does not work: add `https://github.com/git4sim/HA-Toniebox` manually in HACS as a Custom Repository of type **Integration**, search for **Toniebox** and download.
+
+Restart Home Assistant after download.
+
+### Manual Installation
+
+Copy the `custom_components/toniebox/` folder from the [latest release](https://github.com/git4sim/HA-Toniebox/releases/latest) into your HA configuration directory:
+
+```
+/config/custom_components/toniebox/
+```
+
+Restart Home Assistant.
+
+---
+
+## Setup
+
+[![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start?domain=toniebox)
+
+> [!NOTE]
+> If the button does not work: go to **Settings → Devices & Services → Add Integration** and search for **Toniebox**.
+
+Enter the email address and password of your Toniebox account (the same credentials as in the [Toniebox app](https://tonies.com) or on [my.tonies.com](https://my.tonies.com)).
+
+---
+
+## Device Hierarchy
+
+The integration creates a logical device hierarchy in Home Assistant:
+
+```
+Household (Hub)
+├── Toniebox 1       →  Media Player · Switches · Sensors · Buttons · Select
+├── Toniebox 2       →  ...
+├── Creative Tonie A →  Media Player · Chapters · Duration · Sort/Clear Buttons · Live/Private Switch
+└── Creative Tonie B →  ...
+```
+
+Each device appears under **Settings → Devices & Services → Toniebox** with its own entities.
+
+---
+
+## Entities
+
+### Household (Hub device)
+
+| Entity | Description |
+|---|---|
+| `sensor.<household>_account` | Logged-in account (email) |
+| `sensor.<household>_creative_tonies` | Number of Creative Tonies |
+| `sensor.<household>_tonieboxes` | Number of Tonieboxes |
+| `sensor.<household>_children` | Number of child profiles |
+| `sensor.<household>_members` | Number of household members |
+| `sensor.<household>_notifications` | Number of unread notifications |
+| `sensor.<household>_pending_invitations` | Pending invitations |
+| `button.<household>_refresh_all` | Reload all data from server |
+
+### Per Toniebox
+
+| Entity | Description |
+|---|---|
+| `media_player.<toniebox>` | Currently placed figure, cover image, playback position |
+| `switch.<toniebox>_skip_chapters` | Chapter skipping via tap on/off |
+| `switch.<toniebox>_scrubbing` | Scrubbing by tilting on/off |
+| `switch.<toniebox>_offline_mode` | Offline mode |
+| `switch.<toniebox>_tilt_and_tap` | Accelerometer on/off (older boxes) |
+| `sensor.<toniebox>_firmware` | Current firmware version |
+| `sensor.<toniebox>_last_seen` | Timestamp of last connection |
+| `sensor.<toniebox>_online_status` | API online status (connected / offline / unknown) |
+| `sensor.<toniebox>_generation` | Model generation (classic / rosered / tng) |
+| `sensor.<toniebox>_features` | Supported features |
+| `sensor.<toniebox>_timezone` | Configured timezone |
+| `sensor.<toniebox>_setup_wifi` | SSID of setup network |
+| `sensor.<toniebox>_added_at` | Registration date |
+| `sensor.<toniebox>_bedtime_color` | Night light color (tng) |
+| `binary_sensor.<toniebox>_online` | Toniebox recently active (reachability) |
+| `binary_sensor.<toniebox>_led_active` | LED status |
+| `select.<toniebox>_led_level` | LED brightness |
+| `select.<toniebox>_language` | Language setting |
+| `select.<toniebox>_tap_direction` | Tap direction |
+| `select.<toniebox>_age_mode` | Age mode |
+| `number.<toniebox>_max_volume` | Maximum volume |
+| `number.<toniebox>_lightring_brightness` | Light ring brightness |
+| `button.<toniebox>_refresh` | Reload device |
+| `button.<toniebox>_factory_reset` | Reset settings |
+
+### Per Creative Tonie
+
+| Entity | Description |
+|---|---|
+| `media_player.<tonie>` | Main entity with cover image and chapter overview |
+| `sensor.<tonie>_chapters` | Number of chapters (incl. chapter list as attribute) |
+| `sensor.<tonie>_total_duration` | Total playback duration in minutes |
+| `sensor.<tonie>_remaining_time` | Remaining free capacity in minutes (max. 90 min) |
+| `sensor.<tonie>_transcoding` | Transcoding status |
+| `switch.<tonie>_private` | Hide Tonie from guest members |
+| `switch.<tonie>_live` | Enable live mode |
+| `binary_sensor.<tonie>_transcoding` | Transcoding in progress |
+| `binary_sensor.<tonie>_live` | Live status |
+| `binary_sensor.<tonie>_private` | Private status |
+| `button.<tonie>_clear_chapters` | Remove all chapters |
+| `button.<tonie>_sort_by_title` | Sort chapters alphabetically |
+| `button.<tonie>_sort_by_filename` | Sort chapters by filename |
+| `button.<tonie>_sort_by_date` | Sort chapters by date |
+| `button.<tonie>_refresh` | Reload Tonie data |
+| `select.<tonie>_sort_chapters` | Select and apply sort order |
+
+---
+
+## Services
+
+### `toniebox.sort_chapters` — Sort Chapters
+
+```yaml
+service: toniebox.sort_chapters
+data:
+  entity_id: media_player.my_tonie
+  sort_by: title   # title | filename | date
+```
+
+### `toniebox.clear_chapters` — Clear All Chapters
+
+```yaml
+service: toniebox.clear_chapters
+data:
+  entity_id: media_player.my_tonie
+```
+
+### `toniebox.remove_chapter` — Remove a Single Chapter
+
+```yaml
+service: toniebox.remove_chapter
+data:
+  entity_id: media_player.my_tonie
+  chapter_id: "abc123"
+```
+
+> Chapter IDs are available as the `chapters` attribute on the media player or chapter sensor.
+
+### `toniebox.move_chapter` — Move Chapter
+
+```yaml
+service: toniebox.move_chapter
+data:
+  entity_id: media_player.my_tonie
+  chapter_id: "abc123"
+  direction: up   # up | down
+```
+
+### `toniebox.upload_audio` — Upload Audio
+
+```yaml
+service: toniebox.upload_audio
+data:
+  entity_id: media_player.my_tonie
+  file_path: /config/tonie_audio/story.mp3
+  title: "My Story"   # optional
+```
+
+Supported formats: `mp3`, `ogg`, `wav`, `flac`, `m4a`, `aac`, `opus`.
+
+### `toniebox.rename_tonie` — Rename Tonie
+
+```yaml
+service: toniebox.rename_tonie
+data:
+  entity_id: media_player.my_tonie
+  name: "Bedtime Tonie"
+```
+
+### `toniebox.rename_toniebox` — Rename Toniebox
+
+```yaml
+service: toniebox.rename_toniebox
+data:
+  entity_id: media_player.my_toniebox
+  name: "Kids Room"
+```
+
+### `toniebox.redeem_content_token` — Redeem Content Token
+
+```yaml
+service: toniebox.redeem_content_token
+data:
+  entity_id: media_player.my_tonie
+  token: "TOKEN123"
+```
+
+### `toniebox.apply_tune` — Apply Tune to Tonie
+
+```yaml
+service: toniebox.apply_tune
+data:
+  entity_id: media_player.my_tonie
+  tune_id: "tune-id-xyz"
+```
+
+### `toniebox.remove_tune` — Remove Tune (Restore Original)
+
+```yaml
+service: toniebox.remove_tune
+data:
+  entity_id: media_player.my_tonie
+```
+
+### `toniebox.redeem_voucher` — Redeem Voucher Code
+
+```yaml
+service: toniebox.redeem_voucher
+data:
+  code: "VOUCHER123"
+```
+
+### `toniebox.dismiss_all_notifications` — Dismiss All Notifications
+
+```yaml
+service: toniebox.dismiss_all_notifications
+```
+
+### `toniebox.accept_invitation` / `toniebox.decline_invitation` — Accept/Decline Invitation
+
+```yaml
+service: toniebox.accept_invitation
+data:
+  invitation_id: "invitation-id"
+```
+
+---
+
+## Automation Examples
+
+### Turn on light when favourite Tonie is placed
+
+```yaml
+automation:
+  trigger:
+    - platform: state
+      entity_id: binary_sensor.benjamin_bear_currently_active
+      to: "on"
+  action:
+    - service: light.turn_on
+      target:
+        entity_id: light.kids_room
+```
+
+### Volume 100% during the day, reduced to 50% at night
+
+```yaml
+automation:
+  - alias: "Toniebox Volume Day"
+    trigger:
+      - platform: time
+        at: "07:00:00"
+    action:
+      - service: number.set_value
+        target:
+          entity_id: number.kids_room_max_volume
+        data:
+          value: 100
+
+  - alias: "Toniebox Volume Night"
+    trigger:
+      - platform: time
+        at: "20:00:00"
+    action:
+      - service: number.set_value
+        target:
+          entity_id: number.kids_room_max_volume
+        data:
+          value: 50
+```
+
+### Notification when Toniebox goes offline
+
+```yaml
+automation:
+  trigger:
+    - platform: state
+      entity_id: binary_sensor.kids_room_online
+      to: "off"
+      for: "00:05:00"
+  action:
+    - service: notify.mobile_app
+      data:
+        message: "Toniebox Kids Room has been offline for 5 minutes."
+```
+
+---
+
+## Dashboard Example
+
+```yaml
+type: vertical-stack
+cards:
+  - type: picture-entity
+    entity: media_player.my_toniebox
+    show_name: true
+    show_state: true
+  - type: entities
+    title: Creative Tonie
+    entities:
+      - sensor.my_tonie_chapters
+      - sensor.my_tonie_total_duration
+      - sensor.my_tonie_remaining_time
+      - select.my_tonie_sort_chapters
+  - type: horizontal-stack
+    cards:
+      - type: button
+        entity: button.my_tonie_clear_chapters
+        name: "Clear"
+      - type: button
+        entity: button.my_tonie_sort_by_title
+        name: "A–Z"
+      - type: button
+        entity: button.my_tonie_refresh
+        name: "Refresh"
+```
+
+---
+
+## Debug Logging
+
+```yaml
+logger:
+  default: info
+  logs:
+    custom_components.toniebox: debug
+```
+
+Or via **Settings → Devices & Services → Toniebox → Enable debug logging**.
+
+> [!TIP]
+> Debug logs are especially helpful when Creative Tonies or Tonieboxes are not displayed correctly — they show the exact API response fields and help diagnose parsing issues.
+
+---
+
+## 🤖 About Vibecoding
+
+This integration was developed with **AI pair programming** ([Claude by Anthropic](https://anthropic.com)). Architecture, authentication flow and all platforms were built iteratively with AI assistance and tested against a real Toniebox account.
+
+That means: it works — but **edge cases may occur**. PRs, bug reports and improvements are very welcome!
+
+---
+
+## Sources & Attribution
+
+| Source | License | Usage |
+|---|---|---|
+| [Wilhelmsson177/tonie-api](https://github.com/Wilhelmsson177/tonie-api) | MIT | API endpoint research, Python concepts |
+| [maximilianvoss/toniebox-api](https://github.com/maximilianvoss/toniebox-api) | Apache-2.0 | Concrete API URLs from `Constants.java` |
+| [toniebox-reverse-engineering/teddycloud](https://github.com/toniebox-reverse-engineering/teddycloud) | GPL-3.0 | Keycloak SSO flow documentation |
+| [api.tonie.cloud/v2/doc](https://api.tonie.cloud/v2/doc/) | — | Official REST API documentation |
+
+> The endpoints used are part of the official Tonie Cloud API. No DRM protections or access controls are bypassed. The integration uses the same API as the official app.
+
+---
+
+## Legal
+
+- Published under the **[MIT License](LICENSE)**
+- **Not affiliated with Boxine GmbH**
+- Toniebox® and Tonies® are registered trademarks of Boxine GmbH
+- Use in accordance with [Boxine's Terms of Service](https://tonies.com/terms)
+
+---
+
+<!-- GERMAN -->
+# 🇩🇪 Deutsch
 
 ## Features
 
@@ -119,7 +516,7 @@ Jedes Gerät erscheint unter **Einstellungen → Geräte & Dienste → Toniebox*
 | `media_player.<toniebox>` | Aktuell aufgelegte Figur, Cover-Bild, Wiedergabe-Position |
 | `switch.<toniebox>_kapitel_ueberspringen` | Kapitel-Überspringen per Tippen ein/aus |
 | `switch.<toniebox>_vorspulen_zurueckspulen` | Scrubbing durch Kippen ein/aus |
-| `switch.<toniebox>_offline_modus` | Offline-Modus (Anzeige) |
+| `switch.<toniebox>_offline_modus` | Offline-Modus |
 | `switch.<toniebox>_kippen_und_klopfen` | Beschleunigungssensor ein/aus (ältere Boxen) |
 | `sensor.<toniebox>_firmware` | Aktuelle Firmware-Version |
 | `sensor.<toniebox>_zuletzt_gesehen` | Zeitstempel der letzten Verbindung |
@@ -127,7 +524,6 @@ Jedes Gerät erscheint unter **Einstellungen → Geräte & Dienste → Toniebox*
 | `sensor.<toniebox>_generation` | Modell-Generation (classic / rosered / tng) |
 | `sensor.<toniebox>_features` | Unterstützte Funktionen |
 | `sensor.<toniebox>_zeitzone` | Konfigurierte Zeitzone |
-| `sensor.<toniebox>_einstellungen_uebertragen` | Einstellungen synchronisiert (ja/nein) |
 | `sensor.<toniebox>_setup_wlan` | WLAN-SSID des Setup-Netzwerks |
 | `sensor.<toniebox>_hinzugefuegt_am` | Registrierungsdatum |
 | `sensor.<toniebox>_schlafenszeit_farbe` | Nachtlicht-Farbe (tng) |
@@ -422,4 +818,4 @@ Das bedeutet: Es funktioniert — aber **Randfälle können vorkommen**. PRs, Bu
 
 ---
 
-<p align="center">Made with 🧸 + 🤖 + ☕ &nbsp;|&nbsp; <a href="https://github.com/git4sim/HA-Toniebox/issues">Bug melden</a></p>
+<p align="center">Made with 🧸 + 🤖 + ☕ &nbsp;|&nbsp; <a href="https://github.com/git4sim/HA-Toniebox/issues">Report a bug / Bug melden</a></p>

--- a/custom_components/toniebox/manifest.json
+++ b/custom_components/toniebox/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/git4sim/HA-Toniebox/issues",
   "requirements": [],
-  "version": "3.2.6"
+  "version": "3.2.7"
 }

--- a/custom_components/toniebox/services.yaml
+++ b/custom_components/toniebox/services.yaml
@@ -1,29 +1,29 @@
 clear_chapters:
-  name: Kapitel löschen
-  description: Entfernt alle Kapitel von einem Creative Tonie.
+  name: Clear Chapters
+  description: Remove all chapters from a Creative Tonie.
   fields:
     entity_id:
-      name: Entity
-      description: Das Creative Tonie Media Player Entity.
+      name: Creative Tonie
+      description: The media_player entity of the target Creative Tonie.
       required: true
       selector:
         entity:
           domain: media_player
 
 sort_chapters:
-  name: Kapitel sortieren
-  description: Sortiert die Kapitel auf einem Creative Tonie.
+  name: Sort Chapters
+  description: Sort the chapters on a Creative Tonie.
   fields:
     entity_id:
-      name: Entity
-      description: Das Creative Tonie Media Player Entity.
+      name: Creative Tonie
+      description: The media_player entity of the target Creative Tonie.
       required: true
       selector:
         entity:
           domain: media_player
     sort_by:
-      name: Sortierung
-      description: Wie soll sortiert werden?
+      name: Sort By
+      description: Sort chapters by title, filename, or date.
       default: title
       selector:
         select:
@@ -33,43 +33,43 @@ sort_chapters:
             - date
 
 remove_chapter:
-  name: Kapitel entfernen
-  description: Entfernt ein einzelnes Kapitel anhand seiner ID.
+  name: Remove Chapter
+  description: Remove a single chapter by its ID.
   fields:
     entity_id:
-      name: Entity
-      description: Das Creative Tonie Media Player Entity.
+      name: Creative Tonie
+      description: The media_player entity of the target Creative Tonie.
       required: true
       selector:
         entity:
           domain: media_player
     chapter_id:
-      name: Kapitel-ID
-      description: Die ID des zu entfernenden Kapitels (aus dem Attribut 'chapters').
+      name: Chapter ID
+      description: The ID of the chapter to remove (from the 'chapters' attribute).
       required: true
       selector:
         text:
 
 move_chapter:
-  name: Kapitel verschieben
-  description: Verschiebt ein Kapitel auf einem Creative Tonie eine Position nach oben oder unten.
+  name: Move Chapter
+  description: Move a chapter one position up or down on a Creative Tonie.
   fields:
     entity_id:
-      name: Entity
-      description: Das Creative Tonie Media Player Entity.
+      name: Creative Tonie
+      description: The media_player entity of the target Creative Tonie.
       required: true
       selector:
         entity:
           domain: media_player
     chapter_id:
-      name: Kapitel-ID
-      description: Die ID des zu verschiebenden Kapitels (aus dem Attribut 'chapters').
+      name: Chapter ID
+      description: The ID of the chapter to move (from the 'chapters' attribute).
       required: true
       selector:
         text:
     direction:
-      name: Richtung
-      description: "'up' = nach vorne, 'down' = nach hinten."
+      name: Direction
+      description: "'up' moves earlier, 'down' moves later in the list."
       default: up
       selector:
         select:
@@ -78,150 +78,150 @@ move_chapter:
             - down
 
 upload_audio:
-  name: Audio hochladen
+  name: Upload Audio
   description: >
-    Lädt eine lokale Audiodatei hoch und fügt sie als neues Kapitel zu einem
-    Creative Tonie hinzu. Die Datei muss vom Home Assistant Host aus erreichbar
-    sein (z.B. /config/tonie_audio/maerchen.mp3).
-    Unterstützte Formate: mp3, ogg, wav, flac, m4a, aac, opus.
+    Upload a local audio file and add it as a new chapter to a Creative Tonie.
+    The file must be accessible from the Home Assistant host
+    (e.g. /config/tonie_audio/story.mp3).
+    Supported formats: mp3, ogg, wav, flac, m4a, aac, opus.
   fields:
     entity_id:
-      name: Entity
-      description: Das Creative Tonie Media Player Entity.
+      name: Creative Tonie
+      description: The media_player entity of the target Creative Tonie.
       required: true
       selector:
         entity:
           domain: media_player
     file_path:
-      name: Dateipfad
-      description: Absoluter Pfad zur Audiodatei auf dem HA-Host.
+      name: File Path
+      description: Absolute path to the audio file on the HA host.
       required: true
       selector:
         text:
     title:
-      name: Kapitel-Titel
-      description: Titel des neuen Kapitels. Standard ist der Dateiname ohne Erweiterung.
+      name: Chapter Title
+      description: Title of the new chapter. Defaults to the filename without extension.
       required: false
       selector:
         text:
 
 rename_tonie:
-  name: Tonie umbenennen
-  description: Benennt einen Creative Tonie um.
+  name: Rename Tonie
+  description: Rename a Creative Tonie.
   fields:
     entity_id:
-      name: Entity
-      description: Das Creative Tonie Media Player Entity.
+      name: Creative Tonie
+      description: The media_player entity of the target Creative Tonie.
       required: true
       selector:
         entity:
           domain: media_player
     name:
-      name: Neuer Name
-      description: Der neue Name des Tonie.
+      name: New Name
+      description: The new name for the Tonie.
       required: true
       selector:
         text:
 
 rename_toniebox:
-  name: Toniebox umbenennen
-  description: Benennt eine Toniebox um.
+  name: Rename Toniebox
+  description: Rename a Toniebox device.
   fields:
     entity_id:
-      name: Entity
-      description: Das Toniebox Entity.
+      name: Toniebox
+      description: The media_player entity of the Toniebox.
       required: true
       selector:
         entity:
           domain: media_player
     name:
-      name: Neuer Name
-      description: Der neue Name der Toniebox.
+      name: New Name
+      description: The new name for the Toniebox.
       required: true
       selector:
         text:
 
 redeem_content_token:
-  name: Content-Token einlösen
-  description: Löst einen kostenlosen Content-Token für einen Creative Tonie ein.
+  name: Redeem Content Token
+  description: Redeem a free content token onto a Creative Tonie.
   fields:
     entity_id:
-      name: Entity
-      description: Das Creative Tonie Media Player Entity.
+      name: Creative Tonie
+      description: The media_player entity of the target Creative Tonie.
       required: true
       selector:
         entity:
           domain: media_player
     token:
       name: Token
-      description: Der einzulösende Content-Token.
+      description: The content token to redeem.
       required: true
       selector:
         text:
 
 apply_tune:
-  name: Tune anwenden
-  description: Wendet einen gekauften Tune auf einen Tonie an.
+  name: Apply Tune
+  description: Apply a purchased Tune to a Tonie.
   fields:
     entity_id:
-      name: Entity
-      description: Das Tonie Entity.
+      name: Tonie
+      description: The Tonie media_player entity.
       required: true
       selector:
         entity:
           domain: media_player
     tune_id:
-      name: Tune-ID
-      description: Die ID des anzuwendenden Tune.
+      name: Tune ID
+      description: The ID of the tune to apply.
       required: true
       selector:
         text:
 
 remove_tune:
-  name: Tune entfernen
-  description: Entfernt den aktiven Tune von einem Tonie (stellt Originalinhalt wieder her).
+  name: Remove Tune
+  description: Remove the active Tune from a Tonie (restores original content).
   fields:
     entity_id:
-      name: Entity
-      description: Das Tonie Entity.
+      name: Tonie
+      description: The Tonie media_player entity.
       required: true
       selector:
         entity:
           domain: media_player
 
 redeem_voucher:
-  name: Gutschein einlösen
-  description: Löst einen Tunes-Gutscheincode ein.
+  name: Redeem Voucher
+  description: Redeem a Tunes voucher code.
   fields:
     code:
-      name: Gutscheincode
-      description: Der einzulösende Gutscheincode.
+      name: Voucher Code
+      description: The voucher code to redeem.
       required: true
       selector:
         text:
 
 dismiss_all_notifications:
-  name: Alle Benachrichtigungen löschen
-  description: Löscht alle Toniebox-Account-Benachrichtigungen.
+  name: Dismiss All Notifications
+  description: Clear all Toniebox account notifications.
 
 accept_invitation:
-  name: Einladung annehmen
-  description: Nimmt eine ausstehende Haushalt-Einladung an.
+  name: Accept Invitation
+  description: Accept a pending household invitation.
   fields:
     invitation_id:
-      name: Einladungs-ID
-      description: Die ID der Einladung (aus dem Sensor 'Offene Einladungen').
+      name: Invitation ID
+      description: The ID of the invitation (from the 'Pending Invitations' sensor).
       required: true
       selector:
         text:
 
 decline_invitation:
-  name: Einladung ablehnen
-  description: Lehnt eine ausstehende Haushalt-Einladung ab.
+  name: Decline Invitation
+  description: Decline a pending household invitation.
   fields:
     invitation_id:
-      name: Einladungs-ID
-      description: Die ID der Einladung (aus dem Sensor 'Offene Einladungen').
+      name: Invitation ID
+      description: The ID of the invitation (from the 'Pending Invitations' sensor).
       required: true
       selector:
         text:

--- a/custom_components/toniebox/strings.json
+++ b/custom_components/toniebox/strings.json
@@ -124,7 +124,7 @@
       "name": "Accept Invitation",
       "description": "Accept a pending household invitation.",
       "fields": {
-        "invitation_id": { "name": "Invitation ID", "description": "The ID of the invitation (from the 'Offene Einladungen' sensor)." }
+        "invitation_id": { "name": "Invitation ID", "description": "The ID of the invitation (from the 'Pending Invitations' sensor)." }
       }
     },
     "decline_invitation": {


### PR DESCRIPTION
- Translate services.yaml from German to English (primary/fallback language)
- Fix remaining German string in strings.json ('Offene Einladungen' → 'Pending Invitations')
- Rewrite README.md as bilingual EN/DE document (English first, German second)
- Bump version from 3.2.6 to 3.2.7

https://claude.ai/code/session_01ERDkqkDHL3qkT9VuikJH8i