### PR TITLE
feat: ICI MQTT real-time support for TNG Tonieboxes

### DIFF
--- a/custom_components/toniebox/__init__.py
+++ b/custom_components/toniebox/__init__.py
@@ -1,7 +1,8 @@
-"""The Toniebox integration — full API v2."""
+"""The Toniebox integration — full API v2 with ICI real-time push."""
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 from datetime import timedelta
@@ -14,7 +15,11 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DOMAIN, CONF_USERNAME, CONF_PASSWORD, UPDATE_INTERVAL_MINUTES
+from .const import (
+    DOMAIN, CONF_USERNAME, CONF_PASSWORD, UPDATE_INTERVAL_MINUTES,
+    ICI_TOPIC_BATTERY, ICI_TOPIC_ONLINE, ICI_TOPIC_HEADPHONES, ICI_TOPIC_SETTINGS,
+)
+from .ici_client import TonieboxIciClient
 from .tonie_client import TonieCloudClient, TonieCloudAuthError, TonieCloudAPIError
 
 _LOGGER = logging.getLogger(__name__)
@@ -50,6 +55,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except Exception as err:
         raise ConfigEntryNotReady(f"Could not fetch data: {err}") from err
 
+    # Start ICI real-time connection for TNG boxes
+    await coordinator.async_start_ici()
+
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     _register_services(hass)
@@ -58,6 +66,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
+    coordinator = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+    if coordinator and coordinator.ici_client:
+        await coordinator.ici_client.disconnect()
+        coordinator.client.remove_token_listener(coordinator.ici_client.on_token_refreshed)
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
     return unload_ok
@@ -342,16 +354,110 @@ async def _refresh_all(hass: HomeAssistant) -> None:
 # ── Coordinator ───────────────────────────────────────────────────────────────
 
 class TonieboxDataUpdateCoordinator(DataUpdateCoordinator):
-    """Coordinator: fetches ALL data from Tonie Cloud."""
+    """Coordinator: fetches ALL data from Tonie Cloud + ICI real-time push."""
 
     def __init__(self, hass: HomeAssistant, client: TonieCloudClient, entry: ConfigEntry) -> None:
         self.client = client
         self.entry = entry
+        self.ici_client: TonieboxIciClient | None = None
+        self._mac_to_tb: dict[str, tuple[str, str]] = {}  # mac → (hh_id, tb_id)
         super().__init__(
             hass, _LOGGER,
             name=DOMAIN,
             update_interval=timedelta(minutes=UPDATE_INTERVAL_MINUTES),
         )
+
+    async def async_start_ici(self) -> None:
+        """Start ICI MQTT connection for real-time TNG box data."""
+        try:
+            user_uuid = await self.client.get_user_uuid()
+            if not user_uuid:
+                _LOGGER.debug("No user UUID available, skipping ICI")
+                return
+
+            # Collect all TNG boxes with their MAC addresses
+            all_boxes = []
+            for hh_id, hh in self.data.get("households", {}).items():
+                for tb_id, tb in hh.get("tonieboxes", {}).items():
+                    mac = tb.get("mac_address") or ""
+                    if mac:
+                        self._mac_to_tb[mac.upper()] = (hh_id, tb_id)
+                    all_boxes.append({
+                        "id": tb_id,
+                        "name": tb.get("name", tb_id),
+                        "macAddress": mac,
+                        "generation": tb.get("generation"),
+                    })
+
+            tng_boxes = [b for b in all_boxes if b.get("generation") == "tng"]
+            if not tng_boxes:
+                _LOGGER.debug("No TNG boxes found, ICI not needed")
+                return
+
+            self.ici_client = TonieboxIciClient(
+                on_message_callback=self._on_ici_message,
+                loop=asyncio.get_running_loop(),
+            )
+            self.client.add_token_listener(self.ici_client.on_token_refreshed)
+
+            token = self.client.access_token
+            if token:
+                await self.ici_client.connect(user_uuid, token, all_boxes)
+                _LOGGER.info("ICI MQTT started for %d TNG boxes", len(tng_boxes))
+        except Exception:
+            _LOGGER.warning("Failed to start ICI MQTT", exc_info=True)
+
+    def _on_ici_message(self, mac: str, subtopic: str, payload: dict) -> None:
+        """Handle an ICI MQTT message (called from the event loop)."""
+        lookup_mac = mac.upper()
+        tb_ref = self._mac_to_tb.get(lookup_mac)
+        if not tb_ref:
+            _LOGGER.debug("ICI message for unknown MAC %s", mac)
+            return
+
+        hh_id, tb_id = tb_ref
+        data = self.data
+        if not data:
+            return
+
+        tb = (
+            data.get("households", {})
+            .get(hh_id, {})
+            .get("tonieboxes", {})
+            .get(tb_id)
+        )
+        if not tb:
+            return
+
+        updated = False
+
+        if subtopic == ICI_TOPIC_BATTERY and isinstance(payload, dict):
+            tb["battery"] = {
+                "percent": payload.get("percent"),
+                "raw": payload.get("raw"),
+                "status": payload.get("status"),
+            }
+            updated = True
+
+        elif subtopic == ICI_TOPIC_ONLINE and isinstance(payload, dict):
+            state = payload.get("onlineState")
+            if state:
+                tb["online_state"] = state
+                updated = True
+
+        elif subtopic == ICI_TOPIC_HEADPHONES and isinstance(payload, dict):
+            tb["headphones"] = {
+                "output": payload.get("speaker", {}).get("output") if isinstance(payload.get("speaker"), dict) else None,
+                "connected": payload.get("connected", []),
+            }
+            updated = True
+
+        elif subtopic == ICI_TOPIC_SETTINGS:
+            tb["settings_applied"] = True
+            updated = True
+
+        if updated:
+            self.async_set_updated_data(data)
 
     async def _async_update_data(self) -> dict:
         try:
@@ -606,6 +712,21 @@ class TonieboxDataUpdateCoordinator(DataUpdateCoordinator):
                             placed_tonie.setdefault("name", known.get("name"))
                             placed_tonie.setdefault("imageUrl", known.get("image_url"))
 
+                    # Preserve ICI real-time data across REST polling
+                    prev_tb = (
+                        (self.data or {})
+                        .get("households", {}).get(hh_id, {})
+                        .get("tonieboxes", {}).get(b_id, {})
+                    )
+                    ici_online = prev_tb.get("online_state")
+                    rest_online = box.get("onlineState")
+                    # Keep ICI value if REST returns "unsupported" or None
+                    effective_online = (
+                        ici_online
+                        if ici_online in ("connected", "offline") and rest_online in (None, "unsupported")
+                        else rest_online
+                    )
+
                     hh_data["tonieboxes"][b_id] = {
                         # Identity
                         "id": b_id,
@@ -616,7 +737,10 @@ class TonieboxDataUpdateCoordinator(DataUpdateCoordinator):
                         "product": box.get("product"),
                         "features": box.get("features", []),
                         # State
-                        "online_state": box.get("onlineState"),
+                        "online_state": effective_online,
+                        # ICI real-time data (preserved across REST polling)
+                        "battery": prev_tb.get("battery"),
+                        "headphones": prev_tb.get("headphones"),
                         "offline_mode": box.get("offlineMode", False),
                         "firmware_version": box.get("firmwareVersion"),
                         "ssid": box.get("ssid"),

--- a/custom_components/toniebox/binary_sensor.py
+++ b/custom_components/toniebox/binary_sensor.py
@@ -30,11 +30,14 @@ async def async_setup_entry(
     entities: list = []
 
     for hh_id, hh in coordinator.data.get("households", {}).items():
-        for tb_id in hh.get("tonieboxes", {}):
+        for tb_id, tb in hh.get("tonieboxes", {}).items():
             entities += [
                 TonieboxOnlineSensor(coordinator, hh_id, tb_id),
                 TonieboxLEDSensor(coordinator, hh_id, tb_id),
             ]
+            # Charging sensor — TNG boxes only (via ICI real-time push)
+            if tb.get("generation") == "tng":
+                entities.append(TonieboxChargingSensor(coordinator, hh_id, tb_id))
     # ── Content Tonie binary sensors ─────────────────────────────────────────
     for hh_id, hh in coordinator.data.get("households", {}).items():
         for ct_id in hh.get("contenttonies", {}):
@@ -76,10 +79,10 @@ class _TbBin(CoordinatorEntity, BinarySensorEntity):
 
 
 class TonieboxOnlineSensor(_TbBin):
-    """Binary sensor that is True only when the Toniebox has been seen recently.
+    """Binary sensor that reflects the Toniebox online state.
 
-    Uses TONIEBOX_ONLINE_TIMEOUT_MINUTES to determine staleness. This prevents
-    a box that has been offline for weeks from still showing as 'Online'.
+    For TNG boxes with ICI, online_state is updated in real-time via MQTT push.
+    For classic boxes, falls back to last_seen timestamp comparison.
     """
 
     _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
@@ -93,6 +96,12 @@ class TonieboxOnlineSensor(_TbBin):
 
     @property
     def is_on(self) -> bool:
+        # ICI provides reliable real-time state for TNG boxes
+        online_state = self._tb.get("online_state")
+        if online_state in ("connected", "offline"):
+            return online_state == "connected"
+
+        # Fallback: last_seen timestamp for classic boxes or when ICI is unavailable
         last_seen = self._tb.get("last_seen")
         if not last_seen:
             return False
@@ -122,5 +131,24 @@ class TonieboxLEDSensor(_TbBin):
     @property
     def is_on(self) -> bool:
         return self._tb.get("led", True)
+
+
+class TonieboxChargingSensor(_TbBin):
+    """Whether a TNG Toniebox is currently charging (via ICI real-time push)."""
+
+    _attr_device_class = BinarySensorDeviceClass.BATTERY_CHARGING
+    _attr_icon = "mdi:battery-charging"
+    _attr_translation_key = "charging"
+
+    def __init__(self, coordinator, hh_id, tb_id):
+        super().__init__(coordinator, hh_id, tb_id)
+        self._attr_unique_id = f"tb_{tb_id}_charging"
+
+    @property
+    def is_on(self) -> bool | None:
+        battery = self._tb.get("battery")
+        if isinstance(battery, dict):
+            return battery.get("status") == "charging"
+        return None
 
 

--- a/custom_components/toniebox/const.py
+++ b/custom_components/toniebox/const.py
@@ -35,3 +35,12 @@ SORT_BY_TITLE = "title"
 SORT_BY_FILENAME = "filename"
 SORT_BY_DATE = "date"
 SORT_OPTIONS = [SORT_BY_TITLE, SORT_BY_FILENAME, SORT_BY_DATE]
+
+# ICI (MQTT v5 real-time push)
+ICI_HOST = "ici.tonie.cloud"
+ICI_PORT = 443
+ICI_TOPIC_BATTERY = "metrics/battery"
+ICI_TOPIC_ONLINE = "online-state"
+ICI_TOPIC_HEADPHONES = "metrics/headphones"
+ICI_TOPIC_BEDTIME = "app-reply/bedtime-state"
+ICI_TOPIC_SETTINGS = "settings-applied"

--- a/custom_components/toniebox/device_info.py
+++ b/custom_components/toniebox/device_info.py
@@ -11,6 +11,8 @@ All device_info dicts call these helpers so the hierarchy is defined in ONE plac
 """
 from __future__ import annotations
 
+from homeassistant.helpers import device_registry as dr
+
 from .const import DOMAIN
 
 
@@ -34,14 +36,24 @@ def toniebox_device_info(coordinator, hh_id: str, tb_id: str) -> dict:
         .get("tonieboxes", {}).get(tb_id, {})
     )
     fw = tb.get("firmware", {})
-    return {
+    mac = tb.get("mac_address")
+    sw_version = (
+        tb.get("firmware_version")
+        or fw.get("version")
+        or fw.get("toniesVersion")
+    )
+    info = {
         "identifiers": {(DOMAIN, f"tb_{tb_id}")},
         "name": tb.get("name", "Toniebox"),
         "manufacturer": "Boxine GmbH",
         "model": "Toniebox",
-        "sw_version": fw.get("version") or fw.get("toniesVersion"),
+        "serial_number": tb_id,
+        "sw_version": sw_version,
         "via_device": (DOMAIN, f"hh_{hh_id}"),
     }
+    if mac:
+        info["connections"] = {(dr.CONNECTION_NETWORK_MAC, mac.lower())}
+    return info
 
 
 def creative_tonie_device_info(coordinator, hh_id: str, t_id: str) -> dict:

--- a/custom_components/toniebox/ici_client.py
+++ b/custom_components/toniebox/ici_client.py
@@ -1,0 +1,180 @@
+"""ICI MQTT v5 client for real-time Toniebox data (TNG/TB2 only).
+
+Connects to the Tonie Cloud ICI broker via MQTT v5 over WebSocket Secure (WSS)
+and receives real-time push updates for battery, online state, and headphones.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import ssl
+import uuid as uuid_lib
+from typing import Any, Callable
+
+import paho.mqtt.client as mqtt
+
+from .const import (
+    ICI_HOST,
+    ICI_PORT,
+    ICI_TOPIC_BATTERY,
+    ICI_TOPIC_HEADPHONES,
+    ICI_TOPIC_ONLINE,
+    ICI_TOPIC_SETTINGS,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+# Topics we subscribe to for each Toniebox
+_SUBSCRIBE_TOPICS = [
+    ICI_TOPIC_BATTERY,
+    ICI_TOPIC_ONLINE,
+    ICI_TOPIC_HEADPHONES,
+    ICI_TOPIC_SETTINGS,
+]
+
+
+class TonieboxIciClient:
+    """MQTT v5 client for ICI real-time push data."""
+
+    def __init__(
+        self,
+        on_message_callback: Callable[[str, str, dict[str, Any]], None],
+        loop: asyncio.AbstractEventLoop | None = None,
+    ) -> None:
+        self._on_message_callback = on_message_callback
+        self._loop = loop
+        self._client: mqtt.Client | None = None
+        self._connected = False
+        self._boxes: list[dict] = []
+        self._user_uuid: str | None = None
+
+    @property
+    def connected(self) -> bool:
+        """Return True if currently connected to the ICI broker."""
+        return self._connected
+
+    async def connect(
+        self,
+        user_uuid: str,
+        access_token: str,
+        boxes: list[dict],
+    ) -> None:
+        """Connect to ICI broker and subscribe to topics for all TNG boxes."""
+        self._user_uuid = user_uuid
+        self._boxes = [b for b in boxes if b.get("generation") == "tng"]
+
+        if not self._boxes:
+            _LOGGER.debug("No TNG Tonieboxes found, skipping ICI connection")
+            return
+
+        if not self._loop:
+            self._loop = asyncio.get_running_loop()
+
+        random_id = str(uuid_lib.uuid4())
+        client_id = f"{user_uuid}_ha_toniebox_{random_id}_{user_uuid}"
+
+        def _setup_and_connect():
+            """Set up MQTT client (blocking TLS calls) and connect."""
+            self._client = mqtt.Client(
+                callback_api_version=mqtt.CallbackAPIVersion.VERSION2,
+                client_id=client_id,
+                transport="websockets",
+                protocol=mqtt.MQTTv5,
+            )
+            self._client.ws_set_options(path="/")
+            self._client.tls_set(tls_version=ssl.PROTOCOL_TLS_CLIENT)
+            self._client.tls_insecure_set(False)
+            self._client.username_pw_set(username=user_uuid, password=access_token)
+            self._client.on_connect = self._on_connect
+            self._client.on_message = self._on_message
+            self._client.on_disconnect = self._on_disconnect
+            self._client.connect_async(ICI_HOST, ICI_PORT, keepalive=60)
+
+        try:
+            await self._loop.run_in_executor(None, _setup_and_connect)
+            self._client.loop_start()
+            _LOGGER.debug("ICI MQTT connection initiated for %d TNG boxes", len(self._boxes))
+        except Exception:
+            _LOGGER.warning("Failed to connect to ICI broker", exc_info=True)
+
+    async def disconnect(self) -> None:
+        """Disconnect from ICI broker."""
+        if self._client:
+            try:
+                self._client.loop_stop()
+                self._client.disconnect()
+            except Exception:
+                _LOGGER.debug("Error during ICI disconnect", exc_info=True)
+            finally:
+                self._client = None
+                self._connected = False
+
+    async def reconnect(self, new_token: str) -> None:
+        """Reconnect with a new access token."""
+        if not self._user_uuid or not self._boxes:
+            return
+        await self.disconnect()
+        await self.connect(self._user_uuid, new_token, self._boxes)
+
+    def on_token_refreshed(self, new_token: str) -> None:
+        """Called by TonieCloudClient when the token is refreshed."""
+        if not self._connected or not self._loop:
+            return
+        asyncio.run_coroutine_threadsafe(self.reconnect(new_token), self._loop)
+
+    # ── paho-mqtt callbacks (called from network thread) ──────────────────────
+
+    def _on_connect(self, client, userdata, flags, reason_code, properties):
+        rc_str = str(reason_code)
+        if reason_code == 0 or rc_str == "Success":
+            self._connected = True
+            _LOGGER.info("ICI MQTT connected")
+            self._subscribe_all()
+        else:
+            self._connected = False
+            _LOGGER.warning("ICI MQTT connection failed: %s", rc_str)
+
+    def _on_disconnect(self, client, userdata, flags, reason_code, properties):
+        self._connected = False
+        _LOGGER.debug("ICI MQTT disconnected: %s", reason_code)
+
+    def _on_message(self, client, userdata, msg):
+        topic = msg.topic
+        # Topic format: external/toniebox/{MAC}/{subtopic}
+        parts = topic.split("/", 3)
+        if len(parts) < 4 or parts[0] != "external" or parts[1] != "toniebox":
+            return
+
+        mac = parts[2]
+        subtopic = parts[3]
+
+        try:
+            payload = json.loads(msg.payload.decode("utf-8")) if msg.payload else {}
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            _LOGGER.debug("ICI: unparseable payload on %s", topic)
+            return
+
+        _LOGGER.debug("ICI message: %s/%s → %s", mac, subtopic, payload)
+
+        if self._loop and self._on_message_callback:
+            self._loop.call_soon_threadsafe(
+                self._on_message_callback, mac, subtopic, payload
+            )
+
+    # ── Helpers ───────────────────────────────────────────────────────────────
+
+    def _subscribe_all(self) -> None:
+        """Subscribe to all relevant topics for all TNG boxes."""
+        if not self._client:
+            return
+        for box in self._boxes:
+            mac = box.get("macAddress") or box.get("mac_address", "")
+            if not mac:
+                continue
+            name = box.get("name", "?")
+            for subtopic in _SUBSCRIBE_TOPICS:
+                full_topic = f"external/toniebox/{mac}/{subtopic}"
+                self._client.subscribe(full_topic, qos=1)
+                _LOGGER.debug("ICI subscribed: %s (%s)", full_topic, name)

--- a/custom_components/toniebox/manifest.json
+++ b/custom_components/toniebox/manifest.json
@@ -10,6 +10,6 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/git4sim/HA-Toniebox/issues",
-  "requirements": [],
+  "requirements": ["paho-mqtt>=2.0"],
   "version": "3.2.8"
 }

--- a/custom_components/toniebox/sensor.py
+++ b/custom_components/toniebox/sensor.py
@@ -1,10 +1,11 @@
 """Sensor platform — read-only state and info sensors."""
 from __future__ import annotations
 
-from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
@@ -65,6 +66,14 @@ async def async_setup_entry(
             # Bedtime color — only on tng
             if "tngSettings" in features:
                 entities.append(TonieboxBedtimeColorSensor(coordinator, hh_id, tb_id))
+            # ICI sensors — TNG boxes only (battery, headphones via real-time push)
+            generation = tb.get("generation", "")
+            if generation == "tng":
+                entities += [
+                    TonieboxBatterySensor(coordinator, hh_id, tb_id),
+                    TonieboxBatteryStatusSensor(coordinator, hh_id, tb_id),
+                    TonieboxHeadphonesSensor(coordinator, hh_id, tb_id),
+                ]
 
         # ── Creative Tonie sensors ────────────────────────────────────────────
         for t_id in hh.get("creativetonies", {}):
@@ -286,6 +295,8 @@ class TonieboxGenerationSensor(_TbBase):
     @property
     def extra_state_attributes(self):
         return {
+            "device_id": self._tb.get("id"),
+            "mac_address": self._tb.get("mac_address"),
             "product": self._tb.get("product"),
             "offline_mode": self._tb.get("offline_mode"),
         }
@@ -357,6 +368,118 @@ class TonieboxBedtimeColorSensor(_TbBase):
     @property
     def native_value(self):
         return self._tb.get("bedtime_lightring_color")
+
+
+# ── ICI real-time sensors (TNG only) ─────────────────────────────────────────
+
+class _TbIciBase(_TbBase, RestoreEntity):
+    """Base for ICI sensors that restore their last known state on startup."""
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        if (last := await self.async_get_last_state()) and last.state not in (
+            None, "unknown", "unavailable",
+        ):
+            self._restored_state = last.state
+            self._restored_attributes = dict(last.attributes)
+        else:
+            self._restored_state = None
+            self._restored_attributes = {}
+
+
+class TonieboxBatterySensor(_TbIciBase):
+    """Battery level of a TNG Toniebox (via ICI real-time push)."""
+    _attr_has_entity_name = True
+    _attr_device_class = SensorDeviceClass.BATTERY
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = "%"
+    _attr_icon = "mdi:battery"
+    _attr_translation_key = "battery"
+
+    def __init__(self, coordinator, hh_id, tb_id):
+        super().__init__(coordinator, hh_id, tb_id)
+        self._attr_unique_id = f"tb_{tb_id}_battery"
+        self._restored_state = None
+        self._restored_attributes = {}
+
+    @property
+    def native_value(self):
+        battery = self._tb.get("battery")
+        if isinstance(battery, dict):
+            return battery.get("percent")
+        if self._restored_state is not None:
+            try:
+                return int(self._restored_state)
+            except (ValueError, TypeError):
+                pass
+        return None
+
+    @property
+    def extra_state_attributes(self):
+        battery = self._tb.get("battery")
+        if isinstance(battery, dict):
+            return {
+                "raw": battery.get("raw"),
+                "status": battery.get("status"),
+            }
+        return self._restored_attributes if self._restored_attributes else {}
+
+
+class TonieboxBatteryStatusSensor(_TbIciBase):
+    """Charging status of a TNG Toniebox (charging / discharging)."""
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:battery-charging"
+    _attr_translation_key = "battery_status"
+
+    def __init__(self, coordinator, hh_id, tb_id):
+        super().__init__(coordinator, hh_id, tb_id)
+        self._attr_unique_id = f"tb_{tb_id}_battery_status"
+        self._restored_state = None
+        self._restored_attributes = {}
+
+    @property
+    def native_value(self):
+        battery = self._tb.get("battery")
+        if isinstance(battery, dict):
+            return battery.get("status")
+        return self._restored_state
+
+
+class TonieboxHeadphonesSensor(_TbIciBase):
+    """Headphones connection status of a TNG Toniebox."""
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:headphones"
+    _attr_translation_key = "headphones"
+
+    def __init__(self, coordinator, hh_id, tb_id):
+        super().__init__(coordinator, hh_id, tb_id)
+        self._attr_unique_id = f"tb_{tb_id}_headphones"
+        self._restored_state = None
+        self._restored_attributes = {}
+
+    @property
+    def native_value(self):
+        hp = self._tb.get("headphones")
+        if not isinstance(hp, dict):
+            return self._restored_state
+        connected = hp.get("connected", [])
+        if connected:
+            first = connected[0] if isinstance(connected[0], dict) else {}
+            return first.get("type", "bluetooth")
+        output = hp.get("output")
+        return output if output else "speaker"
+
+    @property
+    def extra_state_attributes(self):
+        hp = self._tb.get("headphones")
+        if not isinstance(hp, dict):
+            return self._restored_attributes if self._restored_attributes else {}
+        connected = hp.get("connected", [])
+        attrs = {"output": hp.get("output")}
+        if connected and isinstance(connected[0], dict):
+            attrs["connected_type"] = connected[0].get("type")
+            attrs["connected_battery"] = connected[0].get("battery")
+        return attrs
 
 
 # ── Creative Tonie sensors ────────────────────────────────────────────────────

--- a/custom_components/toniebox/strings.json
+++ b/custom_components/toniebox/strings.json
@@ -162,7 +162,10 @@
       "transcoding": {"name": "Transcoding"},
       "free_minutes": {"name": "Free Time"},
       "current_box": {"name": "Current Box"},
-      "sales_id": {"name": "Series ID"}
+      "sales_id": {"name": "Series ID"},
+      "battery": {"name": "Battery"},
+      "battery_status": {"name": "Battery Status"},
+      "headphones": {"name": "Headphones"}
     },
     "number": {
       "lightring_brightness": {"name": "Ring Brightness"},
@@ -216,7 +219,8 @@
       "led_active": {"name": "LED Active"},
       "currently_active": {"name": "Currently Active"},
       "locked_household": {"name": "Locked to Household"},
-      "transcoding_active": {"name": "Transcoding Active"}
+      "transcoding_active": {"name": "Transcoding Active"},
+      "charging": {"name": "Charging"}
     }
   }
 }

--- a/custom_components/toniebox/tonie_client.py
+++ b/custom_components/toniebox/tonie_client.py
@@ -54,6 +54,8 @@ class TonieCloudClient:
         self._access_token: str | None = None
         self._refresh_token: str | None = None
         self._token_expires_at: float = 0.0
+        self._user_uuid: str | None = None
+        self._token_listeners: list = []
 
     @property
     def _auth_headers(self) -> dict[str, str]:
@@ -61,6 +63,44 @@ class TonieCloudClient:
 
     def _is_token_expired(self) -> bool:
         return time.monotonic() >= (self._token_expires_at - _TOKEN_REFRESH_BUFFER)
+
+    @property
+    def access_token(self) -> str | None:
+        """Return the current access token."""
+        return self._access_token
+
+    @property
+    def refresh_token(self) -> str | None:
+        """Return the current refresh token."""
+        return self._refresh_token
+
+    def add_token_listener(self, callback) -> None:
+        """Register a callback for token refresh events."""
+        self._token_listeners.append(callback)
+
+    def remove_token_listener(self, callback) -> None:
+        """Remove a token refresh callback."""
+        self._token_listeners = [cb for cb in self._token_listeners if cb is not callback]
+
+    def _notify_token_listeners(self) -> None:
+        """Notify listeners that the token has been refreshed."""
+        for callback in self._token_listeners:
+            try:
+                callback(self._access_token)
+            except Exception:
+                _LOGGER.debug("Token listener callback failed", exc_info=True)
+
+    async def get_user_uuid(self) -> str | None:
+        """Get the user UUID from /me, cached after first call."""
+        if self._user_uuid:
+            return self._user_uuid
+        try:
+            me = await self.get_me()
+            self._user_uuid = me.get("uuid") or me.get("id")
+            return self._user_uuid
+        except Exception:
+            _LOGGER.debug("Could not fetch user UUID", exc_info=True)
+            return None
 
     # ── Authentication ────────────────────────────────────────────────────────
 
@@ -90,6 +130,7 @@ class TonieCloudClient:
                 expires_in = token_data.get("expires_in", 300)
                 self._token_expires_at = time.monotonic() + expires_in
                 _LOGGER.debug("Authenticated, token valid for %ss", expires_in)
+                self._notify_token_listeners()
         except aiohttp.ClientError as err:
             raise TonieCloudAuthError(f"Network error: {err}") from err
 
@@ -116,6 +157,7 @@ class TonieCloudClient:
                 self._refresh_token = token_data.get("refresh_token", self._refresh_token)
                 expires_in = token_data.get("expires_in", 300)
                 self._token_expires_at = time.monotonic() + expires_in
+                self._notify_token_listeners()
         except aiohttp.ClientError:
             await self.authenticate()
 

--- a/custom_components/toniebox/translations/de.json
+++ b/custom_components/toniebox/translations/de.json
@@ -162,7 +162,10 @@
       "transcoding": {"name": "Transkodierung"},
       "free_minutes": {"name": "Freie Zeit"},
       "current_box": {"name": "Aktuelle Box"},
-      "sales_id": {"name": "Serien-ID"}
+      "sales_id": {"name": "Serien-ID"},
+      "battery": {"name": "Batterie"},
+      "battery_status": {"name": "Batteriestatus"},
+      "headphones": {"name": "Kopfhörer"}
     },
     "number": {
       "lightring_brightness": {"name": "Helligkeit Ring"},
@@ -216,7 +219,8 @@
       "led_active": {"name": "LED aktiv"},
       "currently_active": {"name": "Gerade aktiv"},
       "locked_household": {"name": "Im Haushalt gesperrt"},
-      "transcoding_active": {"name": "Transkodierung aktiv"}
+      "transcoding_active": {"name": "Transkodierung aktiv"},
+      "charging": {"name": "Wird geladen"}
     }
   }
 }

--- a/custom_components/toniebox/translations/en.json
+++ b/custom_components/toniebox/translations/en.json
@@ -162,7 +162,10 @@
       "transcoding": {"name": "Transcoding"},
       "free_minutes": {"name": "Free Time"},
       "current_box": {"name": "Current Box"},
-      "sales_id": {"name": "Series ID"}
+      "sales_id": {"name": "Series ID"},
+      "battery": {"name": "Battery"},
+      "battery_status": {"name": "Battery Status"},
+      "headphones": {"name": "Headphones"}
     },
     "number": {
       "lightring_brightness": {"name": "Ring Brightness"},
@@ -216,7 +219,8 @@
       "led_active": {"name": "LED Active"},
       "currently_active": {"name": "Currently Active"},
       "locked_household": {"name": "Locked to Household"},
-      "transcoding_active": {"name": "Transcoding Active"}
+      "transcoding_active": {"name": "Transcoding Active"},
+      "charging": {"name": "Charging"}
     }
   }
 }

--- a/custom_components/toniebox/translations/es.json
+++ b/custom_components/toniebox/translations/es.json
@@ -208,7 +208,13 @@
     "sensor": {
       "current_tonie": {
         "name": "Figura actual"
-      }
+      },
+      "battery": {"name": "Batería"},
+      "battery_status": {"name": "Estado de batería"},
+      "headphones": {"name": "Auriculares"}
+    },
+    "binary_sensor": {
+      "charging": {"name": "Cargando"}
     },
     "number": {
       "lightring_brightness": {

--- a/custom_components/toniebox/translations/fr.json
+++ b/custom_components/toniebox/translations/fr.json
@@ -208,7 +208,13 @@
     "sensor": {
       "current_tonie": {
         "name": "Figurine actuelle"
-      }
+      },
+      "battery": {"name": "Batterie"},
+      "battery_status": {"name": "État de la batterie"},
+      "headphones": {"name": "Écouteurs"}
+    },
+    "binary_sensor": {
+      "charging": {"name": "En charge"}
     },
     "number": {
       "lightring_brightness": {

--- a/custom_components/toniebox/translations/it.json
+++ b/custom_components/toniebox/translations/it.json
@@ -208,7 +208,13 @@
     "sensor": {
       "current_tonie": {
         "name": "Figura attuale"
-      }
+      },
+      "battery": {"name": "Batteria"},
+      "battery_status": {"name": "Stato batteria"},
+      "headphones": {"name": "Cuffie"}
+    },
+    "binary_sensor": {
+      "charging": {"name": "In carica"}
     },
     "number": {
       "lightring_brightness": {


### PR DESCRIPTION
## Summary

- Adds real-time battery, charging, online state, and headphones sensors for Toniebox 2 (TNG) via the Tonie Cloud ICI MQTT v5 broker (`ici.tonie.cloud:443` over WSS)
- The REST API returns `onlineState: "unsupported"` and no battery data for TNG boxes — ICI solves this with instant push updates
- Classic/RoseRed boxes are unaffected and continue to work via REST polling as before

## New entities (TNG only)

| Entity | Type | Description |
|--------|------|-------------|
| Battery | Sensor (%) | Battery level with device class |
| Battery Status | Sensor | "charging" / "discharging" |
| Charging | Binary Sensor | Battery charging state |
| Headphones | Sensor | "speaker" / "bluetooth" with connected device details |

## Changes

- **`ici_client.py`** (new) — MQTT v5/WSS client with token refresh and automatic reconnect
- **`tonie_client.py`** — Token listener system so ICI client reconnects on token refresh
- **`__init__.py`** — Coordinator starts/stops ICI, handles messages, preserves ICI data across REST polling
- **`sensor.py`** — Three new ICI sensors with `RestoreEntity` support
- **`binary_sensor.py`** — Charging sensor + Online sensor now uses ICI state for TNG boxes
- **`device_info.py`** — MAC address as device connection, serial number, firmware version fix
- **`const.py`** — ICI constants
- **`manifest.json`** — `paho-mqtt>=2.0` dependency
- **Translations** — All new entities in en, de, es, fr, it

## How it works

```
TonieCloudClient ─── REST API (polling every 5 min) ──→ Settings, Tonies, Playback
                 └── ICI MQTT (real-time push) ────────→ Battery, Online, Headphones
                          │
                          ▼
                 TonieboxDataUpdateCoordinator
                          │
                          ▼
                 Entities (instant updates via async_set_updated_data)
```

## No breaking changes

- Existing entities unchanged
- Config flow unchanged (same credentials, no additional setup)
- REST polling continues as fallback
- ICI only activates for TNG generation boxes

## Test plan

- [x] Battery sensor shows percentage in real-time
- [x] Charging sensor updates instantly on cable connect/disconnect
- [x] Online sensor reflects real-time state via ICI
- [x] Headphones/Speaker sensor updates on connect
- [x] Values persist across HA restarts (RestoreEntity)
- [x] No blocking call warnings
- [x] Classic boxes unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)