### PR TITLE
fix: update last_seen on ICI messages

### DIFF
--- a/custom_components/toniebox/__init__.py
+++ b/custom_components/toniebox/__init__.py
@@ -457,7 +457,7 @@ class TonieboxDataUpdateCoordinator(DataUpdateCoordinator):
             updated = True
 
         if updated:
-            tb["last_seen"] = datetime.now(timezone.utc).isoformat()
+            tb["last_seen"] = datetime.now(timezone.utc)
             self.async_set_updated_data(data)
 
     async def _async_update_data(self) -> dict:

--- a/custom_components/toniebox/sensor.py
+++ b/custom_components/toniebox/sensor.py
@@ -250,6 +250,7 @@ class TonieboxFirmwareSensor(_TbBase):
 
 class TonieboxLastSeenSensor(_TbBase):
     _attr_has_entity_name = True
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
     _attr_icon = "mdi:clock-outline"
     _attr_entity_registry_enabled_default = False
     _attr_translation_key = "last_seen"


### PR DESCRIPTION
## Summary

- The REST API does not return a `lastSeen` field, causing the "Last Seen" sensor to always show "Unknown"
- Now updates `last_seen` with the current UTC timestamp whenever any ICI message is received from a TNG Toniebox
- One-line change in `_on_ici_message()` — sets `tb["last_seen"]` before calling `async_set_updated_data()`

## Test plan

- [x] TNG Toniebox "Last Seen" sensor shows a timestamp instead of "Unknown"
- [x] Timestamp updates in real-time when ICI messages arrive (battery, headphones, online-state)
- [x] Classic boxes remain unaffected (still show "Unknown" as before — no ICI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)