### PR TITLE
feat: v3.5.0 — headphones sub-device, Toniebox image, last_seen ICI fix

### DIFF
--- a/custom_components/toniebox/__init__.py
+++ b/custom_components/toniebox/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -31,6 +31,7 @@ PLATFORMS: list[Platform] = [
     Platform.SWITCH,
     Platform.BINARY_SENSOR,
     Platform.NUMBER,
+    Platform.IMAGE,
 ]
 
 
@@ -457,6 +458,7 @@ class TonieboxDataUpdateCoordinator(DataUpdateCoordinator):
             updated = True
 
         if updated:
+            tb["last_seen"] = datetime.now(timezone.utc)
             self.async_set_updated_data(data)
 
     async def _async_update_data(self) -> dict:

--- a/custom_components/toniebox/binary_sensor.py
+++ b/custom_components/toniebox/binary_sensor.py
@@ -20,7 +20,7 @@ from .content_tonie import (
     DiscActiveBinarySensor,
     DiscLockBinarySensor,
 )
-from .device_info import toniebox_device_info
+from .device_info import toniebox_device_info, headphones_device_info
 
 
 async def async_setup_entry(
@@ -35,9 +35,10 @@ async def async_setup_entry(
                 TonieboxOnlineSensor(coordinator, hh_id, tb_id),
                 TonieboxLEDSensor(coordinator, hh_id, tb_id),
             ]
-            # Charging sensor — TNG boxes only (via ICI real-time push)
+            # ICI sensors — TNG boxes only (via real-time push)
             if tb.get("generation") == "tng":
                 entities.append(TonieboxChargingSensor(coordinator, hh_id, tb_id))
+                entities.append(HeadphonesConnectedSensor(coordinator, hh_id, tb_id))
     # ── Content Tonie binary sensors ─────────────────────────────────────────
     for hh_id, hh in coordinator.data.get("households", {}).items():
         for ct_id in hh.get("contenttonies", {}):
@@ -152,3 +153,34 @@ class TonieboxChargingSensor(_TbBin):
         return None
 
 
+class HeadphonesConnectedSensor(_TbBin):
+    """Whether headphones are connected to a TNG Toniebox (via ICI)."""
+
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _attr_icon = "mdi:headphones"
+    _attr_translation_key = "headphones_connected"
+
+    def __init__(self, coordinator, hh_id, tb_id):
+        super().__init__(coordinator, hh_id, tb_id)
+        self._attr_unique_id = f"tb_{tb_id}_headphones_connected"
+
+    @property
+    def device_info(self) -> dict:
+        return headphones_device_info(self.coordinator, self._hh_id, self._tb_id)
+
+    @property
+    def is_on(self) -> bool | None:
+        hp = self._tb.get("headphones")
+        if not isinstance(hp, dict):
+            return False
+        return len(hp.get("connected", [])) > 0
+
+    @property
+    def extra_state_attributes(self):
+        hp = self._tb.get("headphones")
+        if not isinstance(hp, dict):
+            return {}
+        connected = hp.get("connected", [])
+        if connected and isinstance(connected[0], dict):
+            return {"type": connected[0].get("type")}
+        return {}

--- a/custom_components/toniebox/device_info.py
+++ b/custom_components/toniebox/device_info.py
@@ -3,7 +3,9 @@
 Device hierarchy in Home Assistant:
   Haushalt [Hub/Service]
     ├── Toniebox (Gerät, model="Toniebox")
-    │     entities: media_player, LED switch, mute switch, firmware sensor, last-seen sensor, refresh button
+    │     ├── entities: media_player, LED switch, mute switch, firmware sensor, last-seen sensor, refresh button
+    │     └── Headphones (Sub-Device, model="Tonie Headphones")
+    │           entities: connected binary_sensor, battery sensor, color sensor
     └── Creative Tonie (Gerät, model="Creative Tonie")
           entities: media_player, chapter sensors, sort/clear buttons, private/live switches
 
@@ -54,6 +56,23 @@ def toniebox_device_info(coordinator, hh_id: str, tb_id: str) -> dict:
     if mac:
         info["connections"] = {(dr.CONNECTION_NETWORK_MAC, mac.lower())}
     return info
+
+
+def headphones_device_info(coordinator, hh_id: str, tb_id: str) -> dict:
+    """Headphones sub-device — child of the Toniebox it is connected to."""
+    tb = (
+        coordinator.data
+        .get("households", {}).get(hh_id, {})
+        .get("tonieboxes", {}).get(tb_id, {})
+    )
+    tb_name = tb.get("name", "Toniebox")
+    return {
+        "identifiers": {(DOMAIN, f"tb_{tb_id}_headphones")},
+        "name": f"{tb_name} Headphones",
+        "manufacturer": "Boxine GmbH",
+        "model": "Tonie Headphones",
+        "via_device": (DOMAIN, f"tb_{tb_id}"),
+    }
 
 
 def creative_tonie_device_info(coordinator, hh_id: str, t_id: str) -> dict:

--- a/custom_components/toniebox/image.py
+++ b/custom_components/toniebox/image.py
@@ -1,0 +1,93 @@
+"""Image platform — Toniebox preview image based on bleColorId."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from homeassistant.components.image import ImageEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .device_info import toniebox_device_info
+
+# bleColorId → CDN preview thumbnail (from boxItemPreviews GraphQL query).
+# Note: these URLs are sourced from the Toniebox CDN and may change over time.
+# The image_url API fallback is used when no mapping is found.
+BLE_COLOR_THUMBNAILS: dict[int, str] = {
+    0: "https://cdn.tonies.de/upload/tb2_preview_blue.png",
+    1: "https://cdn.tonies.de/upload/tb2_preview_grey.png",
+    2: "https://cdn.tonies.de/upload/tb2_preview_red.png",
+    3: "https://cdn.tonies.de/upload/tb2_preview_pink.png",
+    4: "https://cdn.tonies.de/upload/tb2_preview_teal.png",
+    5: "https://cdn.tonies.de/upload/tb2_preview_yellow.png",
+}
+
+BLE_COLOR_NAMES: dict[int, str] = {
+    0: "Himmelblau",
+    1: "Mondgrau",
+    2: "Rot",
+    3: "Rosa",
+    4: "Meeresgrün",
+    5: "Blitzgelb",
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    entities: list = []
+
+    for hh_id, hh in coordinator.data.get("households", {}).items():
+        for tb_id in hh.get("tonieboxes", {}):
+            entities.append(TonieboxImage(coordinator, hh_id, tb_id))
+
+    async_add_entities(entities)
+
+
+class TonieboxImage(CoordinatorEntity, ImageEntity):
+    """Preview image of a Toniebox based on its color (bleColorId)."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "toniebox_image"
+
+    def __init__(self, coordinator, hh_id, tb_id):
+        CoordinatorEntity.__init__(self, coordinator)
+        ImageEntity.__init__(self, coordinator.hass)
+        self._hh_id = hh_id
+        self._tb_id = tb_id
+        self._attr_unique_id = f"tb_{tb_id}_image"
+        # Use current time so HA treats the image as fresh on first load
+        self._attr_image_last_updated = datetime.now(timezone.utc)
+
+    @property
+    def _tb(self):
+        return (
+            self.coordinator.data
+            .get("households", {}).get(self._hh_id, {})
+            .get("tonieboxes", {}).get(self._tb_id, {})
+        )
+
+    @property
+    def device_info(self):
+        return toniebox_device_info(self.coordinator, self._hh_id, self._tb_id)
+
+    @property
+    def image_url(self) -> str | None:
+        color_id = self._tb.get("ble_color_id")
+        if color_id is not None and color_id in BLE_COLOR_THUMBNAILS:
+            return BLE_COLOR_THUMBNAILS[color_id]
+        # Fallback to API imageUrl (classic boxes and unknown TNG colors)
+        return self._tb.get("image_url")
+
+    @property
+    def extra_state_attributes(self):
+        color_id = self._tb.get("ble_color_id")
+        if color_id is None:
+            return {}
+        attrs: dict = {"ble_color_id": color_id}
+        if color_id in BLE_COLOR_NAMES:
+            attrs["color_name"] = BLE_COLOR_NAMES[color_id]
+        return attrs

--- a/custom_components/toniebox/manifest.json
+++ b/custom_components/toniebox/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/git4sim/HA-Toniebox/issues",
   "requirements": ["paho-mqtt>=2.0"],
-  "version": "3.4.0"
+  "version": "3.5.0"
 }

--- a/custom_components/toniebox/sensor.py
+++ b/custom_components/toniebox/sensor.py
@@ -20,6 +20,7 @@ from .content_tonie import (
 from .device_info import (
     household_device_info,
     toniebox_device_info,
+    headphones_device_info,
     creative_tonie_device_info,
 )
 
@@ -72,7 +73,9 @@ async def async_setup_entry(
                 entities += [
                     TonieboxBatterySensor(coordinator, hh_id, tb_id),
                     TonieboxBatteryStatusSensor(coordinator, hh_id, tb_id),
-                    TonieboxHeadphonesSensor(coordinator, hh_id, tb_id),
+                    HeadphonesTypeSensor(coordinator, hh_id, tb_id),
+                    HeadphonesBatterySensor(coordinator, hh_id, tb_id),
+                    HeadphonesColorSensor(coordinator, hh_id, tb_id),
                 ]
 
         # ── Creative Tonie sensors ────────────────────────────────────────────
@@ -250,6 +253,7 @@ class TonieboxFirmwareSensor(_TbBase):
 
 class TonieboxLastSeenSensor(_TbBase):
     _attr_has_entity_name = True
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
     _attr_icon = "mdi:clock-outline"
     _attr_entity_registry_enabled_default = False
     _attr_translation_key = "last_seen"
@@ -446,15 +450,23 @@ class TonieboxBatteryStatusSensor(_TbIciBase):
         return self._restored_state
 
 
-class TonieboxHeadphonesSensor(_TbIciBase):
-    """Headphones connection status of a TNG Toniebox."""
+class _HeadphonesBase(_TbIciBase):
+    """Base for sensors belonging to the headphones sub-device."""
+
+    @property
+    def device_info(self):
+        return headphones_device_info(self.coordinator, self._hh_id, self._tb_id)
+
+
+class HeadphonesTypeSensor(_TbIciBase):
+    """Audio output type: speaker (built-in) or bluetooth (headphones connected)."""
     _attr_has_entity_name = True
-    _attr_icon = "mdi:headphones"
-    _attr_translation_key = "headphones"
+    _attr_icon = "mdi:speaker"
+    _attr_translation_key = "audio_output"
 
     def __init__(self, coordinator, hh_id, tb_id):
         super().__init__(coordinator, hh_id, tb_id)
-        self._attr_unique_id = f"tb_{tb_id}_headphones"
+        self._attr_unique_id = f"tb_{tb_id}_audio_output"
 
     @property
     def native_value(self):
@@ -465,20 +477,55 @@ class TonieboxHeadphonesSensor(_TbIciBase):
         if connected:
             first = connected[0] if isinstance(connected[0], dict) else {}
             return first.get("type", "bluetooth")
-        output = hp.get("output")
-        return output if output else "speaker"
+        return "speaker"
+
+
+class HeadphonesBatterySensor(_HeadphonesBase):
+    """Battery level of headphones connected to a TNG Toniebox (via ICI)."""
+    _attr_has_entity_name = True
+    _attr_device_class = SensorDeviceClass.BATTERY
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = "%"
+    _attr_icon = "mdi:headphones"
+    _attr_translation_key = "headphones_battery"
+
+    def __init__(self, coordinator, hh_id, tb_id):
+        super().__init__(coordinator, hh_id, tb_id)
+        self._attr_unique_id = f"tb_{tb_id}_headphones_battery"
 
     @property
-    def extra_state_attributes(self):
+    def native_value(self):
         hp = self._tb.get("headphones")
-        if not isinstance(hp, dict):
-            return self._restored_attributes if self._restored_attributes else {}
-        connected = hp.get("connected", [])
-        attrs = {"output": hp.get("output")}
-        if connected and isinstance(connected[0], dict):
-            attrs["connected_type"] = connected[0].get("type")
-            attrs["connected_battery"] = connected[0].get("battery")
-        return attrs
+        if isinstance(hp, dict):
+            connected = hp.get("connected", [])
+            if connected and isinstance(connected[0], dict):
+                return connected[0].get("battery")
+        if self._restored_state is not None:
+            try:
+                return int(self._restored_state)
+            except (ValueError, TypeError):
+                pass
+        return None
+
+
+class HeadphonesColorSensor(_HeadphonesBase):
+    """Color code of connected headphones (via ICI)."""
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:palette"
+    _attr_translation_key = "headphones_color"
+
+    def __init__(self, coordinator, hh_id, tb_id):
+        super().__init__(coordinator, hh_id, tb_id)
+        self._attr_unique_id = f"tb_{tb_id}_headphones_color"
+
+    @property
+    def native_value(self):
+        hp = self._tb.get("headphones")
+        if isinstance(hp, dict):
+            connected = hp.get("connected", [])
+            if connected and isinstance(connected[0], dict):
+                return connected[0].get("color")
+        return self._restored_state
 
 
 # ── Creative Tonie sensors ────────────────────────────────────────────────────

--- a/custom_components/toniebox/strings.json
+++ b/custom_components/toniebox/strings.json
@@ -165,7 +165,9 @@
       "sales_id": {"name": "Series ID"},
       "battery": {"name": "Battery"},
       "battery_status": {"name": "Battery Status"},
-      "headphones": {"name": "Headphones"}
+      "audio_output": {"name": "Audio Output"},
+      "headphones_battery": {"name": "Headphones Battery"},
+      "headphones_color": {"name": "Color"}
     },
     "number": {
       "lightring_brightness": {"name": "Ring Brightness"},
@@ -214,13 +216,17 @@
       "factory_reset": {"name": "Factory Reset"},
       "remove_tune": {"name": "Remove Tune"}
     },
+    "image": {
+      "toniebox_image": {"name": "Image"}
+    },
     "binary_sensor": {
       "online": {"name": "Online"},
       "led_active": {"name": "LED Active"},
       "currently_active": {"name": "Currently Active"},
       "locked_household": {"name": "Locked to Household"},
       "transcoding_active": {"name": "Transcoding Active"},
-      "charging": {"name": "Charging"}
+      "charging": {"name": "Charging"},
+      "headphones_connected": {"name": "Connected"}
     }
   }
 }

--- a/custom_components/toniebox/translations/de.json
+++ b/custom_components/toniebox/translations/de.json
@@ -165,7 +165,9 @@
       "sales_id": {"name": "Serien-ID"},
       "battery": {"name": "Batterie"},
       "battery_status": {"name": "Batteriestatus"},
-      "headphones": {"name": "Kopfhörer"}
+      "audio_output": {"name": "Audioausgabe"},
+      "headphones_battery": {"name": "Kopfhörer-Batterie"},
+      "headphones_color": {"name": "Farbe"}
     },
     "number": {
       "lightring_brightness": {"name": "Helligkeit Ring"},
@@ -214,13 +216,17 @@
       "factory_reset": {"name": "Auf Werkseinstellungen zurücksetzen"},
       "remove_tune": {"name": "Tune entfernen"}
     },
+    "image": {
+      "toniebox_image": {"name": "Bild"}
+    },
     "binary_sensor": {
       "online": {"name": "Online"},
       "led_active": {"name": "LED aktiv"},
       "currently_active": {"name": "Gerade aktiv"},
       "locked_household": {"name": "Im Haushalt gesperrt"},
       "transcoding_active": {"name": "Transkodierung aktiv"},
-      "charging": {"name": "Wird geladen"}
+      "charging": {"name": "Wird geladen"},
+      "headphones_connected": {"name": "Verbunden"}
     }
   }
 }

--- a/custom_components/toniebox/translations/en.json
+++ b/custom_components/toniebox/translations/en.json
@@ -165,7 +165,9 @@
       "sales_id": {"name": "Series ID"},
       "battery": {"name": "Battery"},
       "battery_status": {"name": "Battery Status"},
-      "headphones": {"name": "Headphones"}
+      "audio_output": {"name": "Audio Output"},
+      "headphones_battery": {"name": "Headphones Battery"},
+      "headphones_color": {"name": "Color"}
     },
     "number": {
       "lightring_brightness": {"name": "Ring Brightness"},
@@ -214,13 +216,17 @@
       "factory_reset": {"name": "Factory Reset"},
       "remove_tune": {"name": "Remove Tune"}
     },
+    "image": {
+      "toniebox_image": {"name": "Image"}
+    },
     "binary_sensor": {
       "online": {"name": "Online"},
       "led_active": {"name": "LED Active"},
       "currently_active": {"name": "Currently Active"},
       "locked_household": {"name": "Locked to Household"},
       "transcoding_active": {"name": "Transcoding Active"},
-      "charging": {"name": "Charging"}
+      "charging": {"name": "Charging"},
+      "headphones_connected": {"name": "Connected"}
     }
   }
 }

--- a/custom_components/toniebox/translations/es.json
+++ b/custom_components/toniebox/translations/es.json
@@ -211,10 +211,16 @@
       },
       "battery": {"name": "Batería"},
       "battery_status": {"name": "Estado de batería"},
-      "headphones": {"name": "Auriculares"}
+      "audio_output": {"name": "Salida de audio"},
+      "headphones_battery": {"name": "Batería de auriculares"},
+      "headphones_color": {"name": "Color"}
+    },
+    "image": {
+      "toniebox_image": {"name": "Imagen"}
     },
     "binary_sensor": {
-      "charging": {"name": "Cargando"}
+      "charging": {"name": "Cargando"},
+      "headphones_connected": {"name": "Conectados"}
     },
     "number": {
       "lightring_brightness": {

--- a/custom_components/toniebox/translations/fr.json
+++ b/custom_components/toniebox/translations/fr.json
@@ -211,10 +211,16 @@
       },
       "battery": {"name": "Batterie"},
       "battery_status": {"name": "État de la batterie"},
-      "headphones": {"name": "Écouteurs"}
+      "audio_output": {"name": "Sortie audio"},
+      "headphones_battery": {"name": "Batterie des écouteurs"},
+      "headphones_color": {"name": "Couleur"}
+    },
+    "image": {
+      "toniebox_image": {"name": "Image"}
     },
     "binary_sensor": {
-      "charging": {"name": "En charge"}
+      "charging": {"name": "En charge"},
+      "headphones_connected": {"name": "Connecté"}
     },
     "number": {
       "lightring_brightness": {

--- a/custom_components/toniebox/translations/it.json
+++ b/custom_components/toniebox/translations/it.json
@@ -211,10 +211,16 @@
       },
       "battery": {"name": "Batteria"},
       "battery_status": {"name": "Stato batteria"},
-      "headphones": {"name": "Cuffie"}
+      "audio_output": {"name": "Uscita audio"},
+      "headphones_battery": {"name": "Batteria cuffie"},
+      "headphones_color": {"name": "Colore"}
+    },
+    "image": {
+      "toniebox_image": {"name": "Immagine"}
     },
     "binary_sensor": {
-      "charging": {"name": "In carica"}
+      "charging": {"name": "In carica"},
+      "headphones_connected": {"name": "Collegato"}
     },
     "number": {
       "lightring_brightness": {


### PR DESCRIPTION
Kombiniert und korrigiert aus PR #10 und PR #11:

**PR #11 — last_seen ICI fix:**
- __init__.py: Setzt tb["last_seen"] bei jeder ICI-Nachricht auf UTC-Zeitstempel
- sensor.py: TonieboxLastSeenSensor bekommt device_class TIMESTAMP

**PR #10 — Headphones Sub-Device + Image-Entity:**
- device_info.py: headphones_device_info() — Kopfhörer als eigenständiges Sub-Device (via_device → Toniebox)
- sensor.py: TonieboxHeadphonesSensor ersetzt durch:
  - HeadphonesTypeSensor (Audio Output: speaker/bluetooth) am Toniebox-Gerät
  - HeadphonesBatterySensor (%) am Headphones-Sub-Device
  - HeadphonesColorSensor (Rohwert) am Headphones-Sub-Device
- binary_sensor.py: HeadphonesConnectedSensor am Headphones-Sub-Device
- image.py: Neue TonieboxImage-Entity mit bleColorId → CDN-Thumbnail-Mapping (Fallback auf API image_url für Classic-Boxen)
- __init__.py: Platform.IMAGE registriert
- strings.json + EN/DE/ES/FR/IT Übersetzungen aktualisiert

**Korrekturen gegenüber den Original-PRs:**
- image.py: _attr_image_last_updated nutzt datetime.now(timezone.utc) statt hardcoded 2025-01-01; CDN-URL-Kommentar ergänzt
- sensor.py: Redundante self._restored_state-Zuweisung in Subklassen entfernt (bereits durch _TbIciBase.__init__ gesetzt)

https://claude.ai/code/session_0193H5Z7TLQFrXXjrSQq1NpH