### PR TITLE
diag: GraphQL-Fehlertext + Introspection loggen (400 Bad Request debu…

### DIFF
--- a/custom_components/toniebox/__init__.py
+++ b/custom_components/toniebox/__init__.py
@@ -619,6 +619,26 @@ class TonieboxDataUpdateCoordinator(DataUpdateCoordinator):
             # All three are available via GraphQL at /v2/graphql.
             gql_placements: dict[str, dict] = {}  # box_id → placement dict
             try:
+                # Introspection: discover root query fields (logged once at WARNING
+                # level so the real field names are visible in HA logs).
+                try:
+                    intro = await self.client.graphql_query(
+                        "{ __schema { queryType { fields { name } } } }"
+                    )
+                    intro_fields = [
+                        f["name"]
+                        for f in (
+                            (intro.get("data") or {})
+                            .get("__schema", {})
+                            .get("queryType", {})
+                            .get("fields", [])
+                        )
+                        if isinstance(f, dict)
+                    ]
+                    _LOGGER.warning("[GQL-SCHEMA] root query fields: %s", intro_fields)
+                except Exception as ie:
+                    _LOGGER.warning("[GQL-SCHEMA] introspection failed: %s", ie)
+
                 gql_resp = await self.client.graphql_query("""
                     {
                       me {

--- a/custom_components/toniebox/tonie_client.py
+++ b/custom_components/toniebox/tonie_client.py
@@ -254,7 +254,12 @@ class TonieCloudClient:
                 ) as r2:
                     r2.raise_for_status()
                     return await r2.json()
-            resp.raise_for_status()
+            if not resp.ok:
+                body = await resp.text()
+                _LOGGER.warning(
+                    "GraphQL HTTP %s — body: %.500s", resp.status, body
+                )
+                resp.raise_for_status()
             return await resp.json()
 
     # ── /me ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
…ggen)

- graphql_query() loggt jetzt den Response-Body bei HTTP-Fehler
- Einmalige __schema-Introspection loggt alle root query fields auf WARNING damit die echten Feldnamen im HA-Log sichtbar sind

https://claude.ai/code/session_01EUhsVmhaMYEM74uVDCChiT