### PR TITLE
Add last-known battery/status sensors and Zuletzt online sensor

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,0 +1,38 @@
+[
+  {
+    "version": "3.7.7",
+    "date": "2026-04-18",
+    "changes": {
+      "added": [
+        "sensor 'Letzte Batterie' (last_battery): zeigt den letzten bekannten Ladestand der TNG-Box, auch wenn die Box offline ist — bleibt über HA-Neustarts erhalten (RestoreEntity)",
+        "sensor 'Letzter Batteriestatus' (last_battery_status): zeigt den letzten bekannten Lade-Status (charging/discharging), auch im Offline-Zustand",
+        "sensor 'Zuletzt online' (last_online): Timestamp der letzten Cloud-Verbindung der TNG-Box (wird gesetzt sobald online_state → 'connected' via ICI-MQTT eintrifft)",
+        "last_battery und last_online_at werden über REST-Poll-Zyklen im Coordinator persistiert"
+      ],
+      "changed": [
+        "sensor 'Batterie' umbenannt zu 'Aktuelle Batterie' (zeigt weiterhin 'Unbekannt' wenn offline)",
+        "sensor 'Batteriestatus' umbenannt zu 'Aktueller Batteriestatus' (zeigt weiterhin 'Unbekannt' wenn offline)",
+        "Übersetzungen aktualisiert: de, en, es, fr, it"
+      ]
+    }
+  },
+  {
+    "version": "3.7.5",
+    "date": "2026-04-12",
+    "changes": {
+      "fixed": [
+        "Stabilitätsfix nach GraphQL-Umstellung"
+      ]
+    }
+  },
+  {
+    "version": "3.7.4",
+    "date": "2026-04-12",
+    "changes": {
+      "fixed": [
+        "GraphQL Relay-Paginierung (edges/node) für myContentTonies, myDiscs und myTonieboxes korrigiert",
+        "GraphQL-Query auf korrekte Endpunkte myContentTonies/myDiscs/myTonieboxes umgestellt"
+      ]
+    }
+  }
+]

--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@
 
 - 🧸 Each **Creative Tonie** as its own device with media player, cover image and chapter list
 - 📻 Each **Toniebox** as its own device — shows the currently placed figure with name and cover
-- 📊 **Sensors** for chapter count, total duration, firmware version, online status, active box
+- 📊 **Sensors** for chapter count, total duration, firmware version, online status, battery level and active box
 - 🔘 **Buttons** to sort (title / filename / date), clear and refresh
 - 🔴 **Binary Sensors** for transcoding, live mode, household lock, active figure
 - 🎛️ **Switches** for LED, chapter skipping, scrubbing, offline mode, household lock
 - 🌐 **Select entities** for language, LED level, tap direction, age mode
-- ⚙️ **13 Services** for automations: sort, clear, rename, apply tune, redeem voucher and more
+- ⚙️ **14 Services** for automations: sort, clear, rename, apply tune, redeem voucher and more
 - 🌍 **Translations** for English, German, French, Spanish and Italian
 - 🔐 Keycloak OpenID Connect authentication — same credentials as the Toniebox app
 - 🛠️ Config Flow setup — **no YAML required**
@@ -122,6 +122,8 @@ Each device appears under **Settings → Devices & Services → Toniebox** with 
 | Entity | Description |
 |---|---|
 | `media_player.<toniebox>` | Currently placed figure, cover image, playback position |
+| `sensor.<toniebox>_current_tonie` | Currently placed figure (name) |
+| `sensor.<toniebox>_settings_applied` | Whether the latest settings have been transmitted |
 | `switch.<toniebox>_skip_chapters` | Chapter skipping via tap on/off |
 | `switch.<toniebox>_scrubbing` | Scrubbing by tilting on/off |
 | `switch.<toniebox>_offline_mode` | Offline mode |
@@ -142,6 +144,7 @@ Each device appears under **Settings → Devices & Services → Toniebox** with 
 | `sensor.<toniebox>_bedtime_color` | Night light color (tng) |
 | `binary_sensor.<toniebox>_online` | Toniebox recently active (reachability) |
 | `binary_sensor.<toniebox>_led_active` | LED status |
+| `binary_sensor.<toniebox>_charging` | Currently charging — unknown when offline (TNG only) |
 | `select.<toniebox>_led_level` | LED brightness |
 | `select.<toniebox>_language` | Language setting |
 | `select.<toniebox>_tap_direction` | Tap direction |
@@ -438,12 +441,12 @@ That means: it works — but **edge cases may occur**. PRs, bug reports and impr
 
 - 🧸 Jede **Creative Tonie** als eigenes Gerät mit Media Player, Cover-Bild und Kapitelliste
 - 📻 Jede **Toniebox** als eigenes Gerät — zeigt die aktuell aufgelegte Figur mit Name und Cover
-- 📊 **Sensoren** für Kapitelanzahl, Gesamtdauer, Firmware-Version, Online-Status, aktive Box
+- 📊 **Sensoren** für Kapitelanzahl, Gesamtdauer, Firmware-Version, Online-Status, Batteriestand und aktive Box
 - 🔘 **Buttons** zum Sortieren (Titel / Dateiname / Datum), Leeren und Aktualisieren
 - 🔴 **Binary Sensors** für Transcoding, Live-Modus, Haushalt-Lock, aktive Figur
 - 🎛️ **Switches** für LED, Kapitel-Überspringen, Scrubbing, Offline-Modus, Haushalt-Sperren
 - 🌐 **Select-Entities** für Sprache, LED-Level, Tap-Richtung, Alters-Modus
-- ⚙️ **13 Services** für Automationen: sortieren, löschen, umbenennen, Tune aufspielen, Gutschein einlösen u.v.m.
+- ⚙️ **14 Services** für Automationen: sortieren, löschen, umbenennen, Tune aufspielen, Gutschein einlösen u.v.m.
 - 🌍 **Übersetzungen** für Deutsch, Englisch, Französisch, Spanisch und Italienisch
 - 🔐 Keycloak OpenID Connect Authentifizierung — selbe Zugangsdaten wie die Toniebox App
 - 🛠️ Config Flow Setup — **kein YAML erforderlich**
@@ -519,6 +522,8 @@ Jedes Gerät erscheint unter **Einstellungen → Geräte & Dienste → Toniebox*
 | Entity | Beschreibung |
 |---|---|
 | `media_player.<toniebox>` | Aktuell aufgelegte Figur, Cover-Bild, Wiedergabe-Position |
+| `sensor.<toniebox>_aktuelle_figur` | Aktuell aufgelegte Figur (Name) |
+| `sensor.<toniebox>_einstellungen_uebertragen` | Ob die aktuellen Einstellungen übertragen wurden |
 | `switch.<toniebox>_kapitel_ueberspringen` | Kapitel-Überspringen per Tippen ein/aus |
 | `switch.<toniebox>_vorspulen_zurueckspulen` | Scrubbing durch Kippen ein/aus |
 | `switch.<toniebox>_offline_modus` | Offline-Modus |
@@ -539,6 +544,7 @@ Jedes Gerät erscheint unter **Einstellungen → Geräte & Dienste → Toniebox*
 | `sensor.<toniebox>_schlafenszeit_farbe` | Nachtlicht-Farbe (tng) |
 | `binary_sensor.<toniebox>_online` | Toniebox zuletzt aktiv (Erreichbarkeit) |
 | `binary_sensor.<toniebox>_led_aktiv` | LED-Status |
+| `binary_sensor.<toniebox>_wird_geladen` | Wird gerade geladen — Unbekannt wenn offline (nur TNG) |
 | `select.<toniebox>_led_level` | LED-Helligkeit |
 | `select.<toniebox>_sprache` | Spracheinstellung |
 | `select.<toniebox>_tap_richtung` | Tipp-Richtung |

--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ Each device appears under **Settings → Devices & Services → Toniebox** with 
 | `sensor.<toniebox>_firmware` | Current firmware version |
 | `sensor.<toniebox>_last_seen` | Timestamp of last connection |
 | `sensor.<toniebox>_online_status` | API online status (connected / offline / unknown) |
+| `sensor.<toniebox>_current_battery` | Live battery level — unknown when offline (TNG only) |
+| `sensor.<toniebox>_current_battery_status` | Live charging status — unknown when offline (TNG only) |
+| `sensor.<toniebox>_last_battery` | Last known battery level while online (TNG only) |
+| `sensor.<toniebox>_last_battery_status` | Last known charging status while online (TNG only) |
+| `sensor.<toniebox>_last_online` | Timestamp of last cloud connection (TNG only) |
 | `sensor.<toniebox>_generation` | Model generation (classic / rosered / tng) |
 | `sensor.<toniebox>_features` | Supported features |
 | `sensor.<toniebox>_timezone` | Configured timezone |
@@ -521,6 +526,11 @@ Jedes Gerät erscheint unter **Einstellungen → Geräte & Dienste → Toniebox*
 | `sensor.<toniebox>_firmware` | Aktuelle Firmware-Version |
 | `sensor.<toniebox>_zuletzt_gesehen` | Zeitstempel der letzten Verbindung |
 | `sensor.<toniebox>_online_status` | API Online-Status (connected / offline / unknown) |
+| `sensor.<toniebox>_aktuelle_batterie` | Live-Ladestand — Unbekannt wenn offline (nur TNG) |
+| `sensor.<toniebox>_aktueller_batteriestatus` | Live-Ladestatus — Unbekannt wenn offline (nur TNG) |
+| `sensor.<toniebox>_letzte_batterie` | Letzter bekannter Ladestand im Online-Zustand (nur TNG) |
+| `sensor.<toniebox>_letzter_batteriestatus` | Letzter bekannter Ladestatus im Online-Zustand (nur TNG) |
+| `sensor.<toniebox>_zuletzt_online` | Zeitstempel der letzten Cloud-Verbindung (nur TNG) |
 | `sensor.<toniebox>_generation` | Modell-Generation (classic / rosered / tng) |
 | `sensor.<toniebox>_features` | Unterstützte Funktionen |
 | `sensor.<toniebox>_zeitzone` | Konfigurierte Zeitzone |

--- a/custom_components/toniebox/__init__.py
+++ b/custom_components/toniebox/__init__.py
@@ -433,17 +433,21 @@ class TonieboxDataUpdateCoordinator(DataUpdateCoordinator):
         updated = False
 
         if subtopic == ICI_TOPIC_BATTERY and isinstance(payload, dict):
-            tb["battery"] = {
+            battery = {
                 "percent": payload.get("percent"),
                 "raw": payload.get("raw"),
                 "status": payload.get("status"),
             }
+            tb["battery"] = battery
+            tb["last_battery"] = battery.copy()
             updated = True
 
         elif subtopic == ICI_TOPIC_ONLINE and isinstance(payload, dict):
             state = payload.get("onlineState")
             if state:
                 tb["online_state"] = state
+                if state == "connected":
+                    tb["last_online_at"] = datetime.now(timezone.utc)
                 updated = True
 
         elif subtopic == ICI_TOPIC_HEADPHONES and isinstance(payload, dict):
@@ -905,6 +909,8 @@ class TonieboxDataUpdateCoordinator(DataUpdateCoordinator):
                         "online_state": effective_online,
                         # ICI real-time data (preserved across REST polling)
                         "battery": prev_tb.get("battery"),
+                        "last_battery": prev_tb.get("last_battery"),
+                        "last_online_at": prev_tb.get("last_online_at"),
                         "headphones": prev_tb.get("headphones"),
                         "offline_mode": box.get("offlineMode", False),
                         "firmware_version": box.get("firmwareVersion"),

--- a/custom_components/toniebox/manifest.json
+++ b/custom_components/toniebox/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/git4sim/HA-Toniebox/issues",
   "requirements": ["paho-mqtt>=2.0"],
-  "version": "3.7.5"
+  "version": "3.7.7"
 }

--- a/custom_components/toniebox/sensor.py
+++ b/custom_components/toniebox/sensor.py
@@ -73,6 +73,9 @@ async def async_setup_entry(
                 entities += [
                     TonieboxBatterySensor(coordinator, hh_id, tb_id),
                     TonieboxBatteryStatusSensor(coordinator, hh_id, tb_id),
+                    TonieboxLastBatterySensor(coordinator, hh_id, tb_id),
+                    TonieboxLastBatteryStatusSensor(coordinator, hh_id, tb_id),
+                    TonieboxLastOnlineSensor(coordinator, hh_id, tb_id),
                     HeadphonesTypeSensor(coordinator, hh_id, tb_id),
                     HeadphonesBatterySensor(coordinator, hh_id, tb_id),
                     HeadphonesColorSensor(coordinator, hh_id, tb_id),
@@ -482,6 +485,73 @@ class TonieboxBatteryStatusSensor(_TbIciBase):
         if isinstance(battery, dict):
             return battery.get("status")
         return self._restored_state
+
+
+class TonieboxLastBatterySensor(_TbIciBase):
+    """Last known battery level when the TNG Toniebox was online."""
+    _attr_has_entity_name = True
+    _attr_device_class = SensorDeviceClass.BATTERY
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = "%"
+    _attr_icon = "mdi:battery-clock"
+    _attr_translation_key = "last_battery"
+
+    def __init__(self, coordinator, hh_id, tb_id):
+        super().__init__(coordinator, hh_id, tb_id)
+        self._attr_unique_id = f"tb_{tb_id}_last_battery"
+
+    @property
+    def native_value(self):
+        last = self._tb.get("last_battery")
+        if isinstance(last, dict) and last.get("percent") is not None:
+            return last["percent"]
+        if self._restored_state is not None:
+            try:
+                return int(self._restored_state)
+            except (ValueError, TypeError):
+                pass
+        return None
+
+    @property
+    def extra_state_attributes(self):
+        last = self._tb.get("last_battery")
+        if isinstance(last, dict):
+            return {"raw": last.get("raw"), "status": last.get("status")}
+        return self._restored_attributes if self._restored_attributes else {}
+
+
+class TonieboxLastBatteryStatusSensor(_TbIciBase):
+    """Last known charging status when the TNG Toniebox was online."""
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:battery-charging-outline"
+    _attr_translation_key = "last_battery_status"
+
+    def __init__(self, coordinator, hh_id, tb_id):
+        super().__init__(coordinator, hh_id, tb_id)
+        self._attr_unique_id = f"tb_{tb_id}_last_battery_status"
+
+    @property
+    def native_value(self):
+        last = self._tb.get("last_battery")
+        if isinstance(last, dict):
+            return last.get("status")
+        return self._restored_state
+
+
+class TonieboxLastOnlineSensor(_TbBase):
+    """Timestamp of the last time the TNG Toniebox connected to the cloud."""
+    _attr_has_entity_name = True
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_icon = "mdi:clock-check-outline"
+    _attr_translation_key = "last_online"
+
+    def __init__(self, coordinator, hh_id, tb_id):
+        super().__init__(coordinator, hh_id, tb_id)
+        self._attr_unique_id = f"tb_{tb_id}_last_online"
+
+    @property
+    def native_value(self):
+        return self._tb.get("last_online_at")
 
 
 class _HeadphonesBase(_TbIciBase):

--- a/custom_components/toniebox/strings.json
+++ b/custom_components/toniebox/strings.json
@@ -163,8 +163,11 @@
       "free_minutes": {"name": "Free Time"},
       "current_box": {"name": "Current Box"},
       "sales_id": {"name": "Series ID"},
-      "battery": {"name": "Battery"},
-      "battery_status": {"name": "Battery Status"},
+      "battery": {"name": "Current Battery"},
+      "battery_status": {"name": "Current Battery Status"},
+      "last_battery": {"name": "Last Battery"},
+      "last_battery_status": {"name": "Last Battery Status"},
+      "last_online": {"name": "Last Online"},
       "audio_output": {"name": "Audio Output"},
       "headphones_battery": {"name": "Headphones Battery"},
       "headphones_color": {"name": "Color"}

--- a/custom_components/toniebox/translations/de.json
+++ b/custom_components/toniebox/translations/de.json
@@ -163,8 +163,11 @@
       "free_minutes": {"name": "Freie Zeit"},
       "current_box": {"name": "Aktuelle Box"},
       "sales_id": {"name": "Serien-ID"},
-      "battery": {"name": "Batterie"},
-      "battery_status": {"name": "Batteriestatus"},
+      "battery": {"name": "Aktuelle Batterie"},
+      "battery_status": {"name": "Aktueller Batteriestatus"},
+      "last_battery": {"name": "Letzte Batterie"},
+      "last_battery_status": {"name": "Letzter Batteriestatus"},
+      "last_online": {"name": "Zuletzt online"},
       "audio_output": {"name": "Audioausgabe"},
       "headphones_battery": {"name": "Kopfhörer-Batterie"},
       "headphones_color": {"name": "Farbe"}

--- a/custom_components/toniebox/translations/en.json
+++ b/custom_components/toniebox/translations/en.json
@@ -163,8 +163,11 @@
       "free_minutes": {"name": "Free Time"},
       "current_box": {"name": "Current Box"},
       "sales_id": {"name": "Series ID"},
-      "battery": {"name": "Battery"},
-      "battery_status": {"name": "Battery Status"},
+      "battery": {"name": "Current Battery"},
+      "battery_status": {"name": "Current Battery Status"},
+      "last_battery": {"name": "Last Battery"},
+      "last_battery_status": {"name": "Last Battery Status"},
+      "last_online": {"name": "Last Online"},
       "audio_output": {"name": "Audio Output"},
       "headphones_battery": {"name": "Headphones Battery"},
       "headphones_color": {"name": "Color"}

--- a/custom_components/toniebox/translations/es.json
+++ b/custom_components/toniebox/translations/es.json
@@ -209,8 +209,11 @@
       "current_tonie": {
         "name": "Figura actual"
       },
-      "battery": {"name": "Batería"},
-      "battery_status": {"name": "Estado de batería"},
+      "battery": {"name": "Batería actual"},
+      "battery_status": {"name": "Estado de batería actual"},
+      "last_battery": {"name": "Última batería"},
+      "last_battery_status": {"name": "Último estado de batería"},
+      "last_online": {"name": "Última vez en línea"},
       "audio_output": {"name": "Salida de audio"},
       "headphones_battery": {"name": "Batería de auriculares"},
       "headphones_color": {"name": "Color"}

--- a/custom_components/toniebox/translations/fr.json
+++ b/custom_components/toniebox/translations/fr.json
@@ -209,8 +209,11 @@
       "current_tonie": {
         "name": "Figurine actuelle"
       },
-      "battery": {"name": "Batterie"},
-      "battery_status": {"name": "État de la batterie"},
+      "battery": {"name": "Batterie actuelle"},
+      "battery_status": {"name": "État actuel de la batterie"},
+      "last_battery": {"name": "Dernière batterie"},
+      "last_battery_status": {"name": "Dernier état de la batterie"},
+      "last_online": {"name": "Dernière connexion"},
       "audio_output": {"name": "Sortie audio"},
       "headphones_battery": {"name": "Batterie des écouteurs"},
       "headphones_color": {"name": "Couleur"}

--- a/custom_components/toniebox/translations/it.json
+++ b/custom_components/toniebox/translations/it.json
@@ -209,8 +209,11 @@
       "current_tonie": {
         "name": "Figura attuale"
       },
-      "battery": {"name": "Batteria"},
-      "battery_status": {"name": "Stato batteria"},
+      "battery": {"name": "Batteria attuale"},
+      "battery_status": {"name": "Stato batteria attuale"},
+      "last_battery": {"name": "Ultima batteria"},
+      "last_battery_status": {"name": "Ultimo stato batteria"},
+      "last_online": {"name": "Ultima volta online"},
       "audio_output": {"name": "Uscita audio"},
       "headphones_battery": {"name": "Batteria cuffie"},
       "headphones_color": {"name": "Colore"}


### PR DESCRIPTION
- Rename battery sensors to "Aktuelle Batterie" / "Aktueller Batteriestatus"
  (still show Unbekannt when offline – no behaviour change)
- Add "Letzte Batterie" + "Letzter Batteriestatus" sensors that always
  display the last values received while the box was online (persisted via
  RestoreEntity across HA restarts)
- Add "Zuletzt online" timestamp sensor (set whenever online_state → connected)
- Persist last_battery and last_online_at across REST polling cycles in coordinator
- All translations updated (de/en/es/fr/it)

https://claude.ai/code/session_01DPwEFnT11UVndbrrpgXG5B