### PR TITLE
fix: add Platform.MEDIA_PLAYER to PLATFORMS list

### DIFF
--- a/custom_components/toniebox/__init__.py
+++ b/custom_components/toniebox/__init__.py
@@ -32,6 +32,7 @@ PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.NUMBER,
     Platform.IMAGE,
+    Platform.MEDIA_PLAYER,
 ]
 
 


### PR DESCRIPTION
media_player.py is fully implemented with TonieboxPlayer and CreativeToniePlayer entities, but Platform.MEDIA_PLAYER is missing from the PLATFORMS list in __init__.py. As a result, no media player entities are ever registered in 
  Home Assistant. 