### PR TITLE
Fix media_player platform not loading, speed up ICI re-auth

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,5 +1,15 @@
 [
   {
+    "version": "3.7.10",
+    "date": "2026-07-23",
+    "changes": {
+      "fixed": [
+        "media_player-Plattform wurde nie geladen (fehlte in PLATFORMS) — Media Player für Toniebox und Creative Tonies werden jetzt korrekt angelegt (#26)",
+        "ICI MQTT: nach einem Auth-Fehler wird der Access Token jetzt sofort erneuert statt bis zum nächsten Poll-Zyklus (bis zu 5 Min.) zu warten (#27)"
+      ]
+    }
+  },
+  {
     "version": "3.7.7",
     "date": "2026-04-18",
     "changes": {

--- a/custom_components/toniebox/__init__.py
+++ b/custom_components/toniebox/__init__.py
@@ -32,6 +32,7 @@ PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.NUMBER,
     Platform.IMAGE,
+    Platform.MEDIA_PLAYER,
 ]
 
 
@@ -398,6 +399,7 @@ class TonieboxDataUpdateCoordinator(DataUpdateCoordinator):
             self.ici_client = TonieboxIciClient(
                 on_message_callback=self._on_ici_message,
                 loop=asyncio.get_running_loop(),
+                on_auth_failed=self._on_ici_auth_failed,
             )
             self.client.add_token_listener(self.ici_client.on_token_refreshed)
 
@@ -407,6 +409,18 @@ class TonieboxDataUpdateCoordinator(DataUpdateCoordinator):
                 _LOGGER.info("ICI MQTT started for %d TNG boxes", len(tng_boxes))
         except Exception:
             _LOGGER.warning("Failed to start ICI MQTT", exc_info=True)
+
+    async def _on_ici_auth_failed(self) -> None:
+        """Called by the ICI client when the MQTT broker rejects the access token.
+
+        Forces an immediate REST token refresh instead of waiting for the next
+        poll cycle; the refresh notifies the ICI client's token listener, which
+        reconnects with the new token.
+        """
+        try:
+            await self.client.async_refresh_token()
+        except Exception:
+            _LOGGER.debug("Proactive token refresh after ICI auth failure failed", exc_info=True)
 
     def _on_ici_message(self, mac: str, subtopic: str, payload: dict) -> None:
         """Handle an ICI MQTT message (called from the event loop)."""

--- a/custom_components/toniebox/const.py
+++ b/custom_components/toniebox/const.py
@@ -43,3 +43,8 @@ ICI_TOPIC_BATTERY = "metrics/battery"
 ICI_TOPIC_ONLINE = "online-state"
 ICI_TOPIC_HEADPHONES = "metrics/headphones"
 ICI_TOPIC_SETTINGS = "settings-applied"
+# Reported (unverified against a live account) to push Tonie placement /
+# playback events in real time. Subscribed for observation only for now —
+# see _on_message's debug log for the raw payload shape before wiring it
+# into any entity state.
+ICI_TOPIC_PLAYBACK = "playback/state"

--- a/custom_components/toniebox/ici_client.py
+++ b/custom_components/toniebox/ici_client.py
@@ -21,6 +21,7 @@ from .const import (
     ICI_TOPIC_BATTERY,
     ICI_TOPIC_HEADPHONES,
     ICI_TOPIC_ONLINE,
+    ICI_TOPIC_PLAYBACK,
     ICI_TOPIC_SETTINGS,
 )
 
@@ -32,6 +33,8 @@ _SUBSCRIBE_TOPICS = [
     ICI_TOPIC_ONLINE,
     ICI_TOPIC_HEADPHONES,
     ICI_TOPIC_SETTINGS,
+    # Observation only for now — see const.py note on ICI_TOPIC_PLAYBACK.
+    ICI_TOPIC_PLAYBACK,
 ]
 
 

--- a/custom_components/toniebox/ici_client.py
+++ b/custom_components/toniebox/ici_client.py
@@ -42,9 +42,11 @@ class TonieboxIciClient:
         self,
         on_message_callback: Callable[[str, str, dict[str, Any]], None],
         loop: asyncio.AbstractEventLoop | None = None,
+        on_auth_failed: Callable[[], Any] | None = None,
     ) -> None:
         self._on_message_callback = on_message_callback
         self._loop = loop
+        self._on_auth_failed = on_auth_failed
         self._client: mqtt.Client | None = None
         self._connected = False
         self._boxes: list[dict] = []
@@ -124,6 +126,21 @@ class TonieboxIciClient:
                 self._client = None
                 self._connected = False
 
+    async def _handle_auth_failure(self) -> None:
+        """Clean up after an MQTT auth failure and ask for a fresh token now.
+
+        Without this, ICI would sit idle until the next REST poll cycle
+        (up to UPDATE_INTERVAL_MINUTES) happened to refresh the token.
+        """
+        await self.disconnect()
+        if self._on_auth_failed:
+            try:
+                result = self._on_auth_failed()
+                if result is not None:
+                    await result
+            except Exception:
+                _LOGGER.debug("ICI on_auth_failed callback raised", exc_info=True)
+
     async def reconnect(self, new_token: str) -> None:
         """Reconnect with a new access token."""
         if not self._user_uuid or not self._boxes:
@@ -171,7 +188,7 @@ class TonieboxIciClient:
                 # before the async cleanup below has a chance to run.
                 client.disconnect()
                 if self._loop:
-                    asyncio.run_coroutine_threadsafe(self.disconnect(), self._loop)
+                    asyncio.run_coroutine_threadsafe(self._handle_auth_failure(), self._loop)
         else:
             self._connected = False
             _LOGGER.warning("ICI MQTT connection failed: %s", rc_str)

--- a/custom_components/toniebox/manifest.json
+++ b/custom_components/toniebox/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/git4sim/HA-Toniebox/issues",
   "requirements": ["paho-mqtt>=2.0"],
-  "version": "3.7.9"
+  "version": "3.7.10"
 }

--- a/custom_components/toniebox/tonie_client.py
+++ b/custom_components/toniebox/tonie_client.py
@@ -134,6 +134,10 @@ class TonieCloudClient:
         except aiohttp.ClientError as err:
             raise TonieCloudAuthError(f"Network error: {err}") from err
 
+    async def async_refresh_token(self) -> None:
+        """Force a token refresh now (e.g. after an ICI MQTT auth failure)."""
+        await self._refresh_access_token()
+
     async def _refresh_access_token(self) -> None:
         if not self._refresh_token:
             await self.authenticate()


### PR DESCRIPTION
Platform.MEDIA_PLAYER was missing from PLATFORMS in __init__.py, so
media_player.py's entities were never created despite the platform
being fully implemented (#26).

ICI MQTT auth failures previously waited for the next REST poll cycle
(up to 5 min) to pick up a refreshed token. Add an on_auth_failed hook
so the ICI client can trigger an immediate token refresh, which
reconnects via the existing token-listener path (#27).

Bump to 3.7.10 and update CHANGELOG.