### PR TITLE
Fix ICI MQTT TLS setup crash (wrong paho API + race on shared client)

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,5 +1,15 @@
 [
   {
+    "version": "3.7.11",
+    "date": "2026-07-23",
+    "changes": {
+      "fixed": [
+        "ICI MQTT: tls_set(ssl_context=...) ist bei keiner paho-mqtt-Version gültig und schlug immer fehl; jetzt wird korrekt tls_set_context() verwendet",
+        "ICI MQTT: TLS-Setup lief teilweise auf dem geteilten self._client-Attribut — bei überlappenden Connect-Versuchen konnte das zu 'SSL/TLS has already been configured' führen; Setup läuft jetzt auf einer lokalen Variable und wird erst am Ende veröffentlicht"
+      ]
+    }
+  },
+  {
     "version": "3.7.10",
     "date": "2026-07-23",
     "changes": {

--- a/custom_components/toniebox/ici_client.py
+++ b/custom_components/toniebox/ici_client.py
@@ -84,31 +84,32 @@ class TonieboxIciClient:
         client_id = f"{user_uuid}_ha_toniebox_{random_id}"
 
         def _setup_and_connect():
-            """Set up MQTT client (blocking TLS calls) and connect."""
-            self._client = mqtt.Client(
+            """Set up MQTT client (blocking TLS calls) and connect.
+
+            Builds the client on a local variable and only publishes it to
+            self._client once fully configured, so a concurrent connect/
+            reconnect for this instance can't observe (or race on) a
+            partially-configured client via the shared attribute.
+            """
+            client = mqtt.Client(
                 callback_api_version=mqtt.CallbackAPIVersion.VERSION2,
                 client_id=client_id,
                 transport="websockets",
                 protocol=mqtt.MQTTv5,
             )
-            self._client.ws_set_options(path="/")
-            # Use create_default_context() for full cert verification;
-            # avoids the deprecated ssl.PROTOCOL_TLS_CLIENT path in paho that
-            # can leave _ssl_context unset and break tls_insecure_set().
-            ssl_ctx = ssl.create_default_context()
-            try:
-                self._client.tls_set(ssl_context=ssl_ctx)
-            except TypeError:
-                # paho-mqtt < 2.0 does not support the ssl_context kwarg;
-                # initialise TLS normally and then swap in our context.
-                self._client.tls_set()
-                self._client._ssl_context = ssl_ctx
-            self._client.username_pw_set(username=user_uuid, password=access_token)
-            self._client.reconnect_delay_set(min_delay=5, max_delay=120)
-            self._client.on_connect = self._on_connect
-            self._client.on_message = self._on_message
-            self._client.on_disconnect = self._on_disconnect
-            self._client.connect_async(ICI_HOST, ICI_PORT, keepalive=60)
+            client.ws_set_options(path="/")
+            # tls_set() never accepts an ssl_context kwarg in any paho-mqtt
+            # version — tls_set_context() is the correct API for supplying a
+            # pre-built ssl.SSLContext (here from create_default_context()
+            # for full cert verification).
+            client.tls_set_context(ssl.create_default_context())
+            client.username_pw_set(username=user_uuid, password=access_token)
+            client.reconnect_delay_set(min_delay=5, max_delay=120)
+            client.on_connect = self._on_connect
+            client.on_message = self._on_message
+            client.on_disconnect = self._on_disconnect
+            client.connect_async(ICI_HOST, ICI_PORT, keepalive=60)
+            self._client = client
 
         try:
             await self._loop.run_in_executor(None, _setup_and_connect)

--- a/custom_components/toniebox/manifest.json
+++ b/custom_components/toniebox/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/git4sim/HA-Toniebox/issues",
   "requirements": ["paho-mqtt>=2.0"],
-  "version": "3.7.10"
+  "version": "3.7.11"
 }


### PR DESCRIPTION
## Summary
- `tls_set(ssl_context=...)` is not valid on any paho-mqtt version — `Client.tls_set()` has never had that parameter, so every ICI connect attempt hit `TypeError` and fell through to a fallback path.
- That fallback read/wrote the shared `self._client` attribute at every step, so an overlapping connect/reconnect for the same `TonieboxIciClient` instance could observe a client another thread was still configuring, surfacing as paho's `ValueError: SSL/TLS has already been configured.` (reported live from a user's HA log).
- Fix: use `tls_set_context()` directly (the correct API for a pre-built `ssl.SSLContext`), and build the whole client on a local variable, only publishing it to `self._client` once fully configured — removing the race entirely.
- Bump to v3.7.11 with a CHANGELOG entry.

## Test plan
- [ ] `python3 -m py_compile` passes on the changed file (done locally)
- [ ] Verify on a real Home Assistant instance that the ICI MQTT connection comes up cleanly with no `tls_set`/`SSL/TLS has already been configured` errors in the log

---
_Generated by [Claude Code](https://claude.ai/code/session_016ieynC9Wo9bMCiVMa9U1GL)_