### PR TITLE
Add TNG playback control, sleep timer, and chapter shuffle-on-swap

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,8 @@
 {
   "permissions": {
     "allow": [
-      "WebFetch(domain:api.tonie.cloud)"
+      "WebFetch(domain:api.tonie.cloud)",
+      "mcp__bf7c680d-5fdc-5ef4-b4a0-abadb619bf0a__subscribe_pr_activity"
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,7 @@ dist/
 build/
 .env
 .venv/
+.venv-*/
+tests/
+pytest.ini
 *.zip

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,5 +1,27 @@
 [
   {
+    "version": "3.7.12",
+    "date": "2026-08-01",
+    "changes": {
+      "added": [
+        "Live-Wiedergabesteuerung auf der Toniebox 2 (TNG): Play/Pause, Kapitel vor/zurück, Lautstärke, Kapitel-Browse und Schlafenlegen — über den ICI-Echtzeitkanal, wie die offizielle App",
+        "sensor 'Aktuelle Figur ID' (current_tonie_id): rohe Tonie-ID der aktuell aufgelegten Figur, nützlich als Automations-Trigger",
+        "Action 'toniebox.sleeptimer' + binary_sensor 'Schlaftimer aktiv' (sleeptimer_active) für die Toniebox 2 (TNG)",
+        "sort_chapters: neue Sortierung 'random' — mischt die Kapitel eines Kreativ-Tonies in eine zufällige Reihenfolge (löst wie jede Umsortierung ein Neu-Transkodieren aus)",
+        "Button 'Kapitel mischen' pro Kreativ-Tonie zum direkten Zufallsmischen",
+        "Schalter 'Beim Wechsel mischen' pro Kreativ-Tonie: mischt die Kapitel automatisch, sobald der Tonie auf einer Box durch einen anderen Tonie verdrängt wird (nur Kreativ-Tonies mit mindestens 2 Kapiteln; reines Abnehmen löst nichts aus). Erkennung live via ICI-MQTT (TNG); auf klassischen (Nicht-TNG) Boxen aktuell nicht verfügbar, da keine Placement-Datenquelle existiert"
+      ],
+      "fixed": [
+        "playback/state-Payload live gegen einen echten Account verifiziert: 'tonie' ist ein flacher ID-String statt eines Objekts — die aktuell aufgelegte Figur wird dadurch zuverlässig erkannt (#24)",
+        "GraphQL-Feldnamen für Content Tonies/Discs korrigiert (title/lock/languageName statt name/locked/language; series.name als Produktlinie)",
+        "GraphQL-Platzierungsabfrage für Tonieboxen entfernt (das Feld existiert dort nicht) — Platzierung kommt jetzt ausschließlich von ICI"
+      ],
+      "changed": [
+        "Sortier-Auswahl (select 'Kapitel sortieren') entfernt — alle vier Sortiermodi (Titel/Dateiname/Datum/Zufall) gibt es jetzt als Buttons; die alte Select-Entität wird nach dem Update als 'nicht verfügbar' angezeigt und kann gelöscht werden"
+      ]
+    }
+  },
+  {
     "version": "3.7.11",
     "date": "2026-07-23",
     "changes": {

--- a/README.md
+++ b/README.md
@@ -41,12 +41,16 @@
 
 - 🧸 Each **Creative Tonie** as its own device with media player, cover image and chapter list
 - 📻 Each **Toniebox** as its own device — shows the currently placed figure with name and cover
-- 📊 **Sensors** for chapter count, total duration, firmware version, online status, battery level and active box
-- 🔘 **Buttons** to sort (title / filename / date), clear and refresh
-- 🔴 **Binary Sensors** for transcoding, live mode, household lock, active figure
+- ▶️ **Full playback control on the Toniebox 2 (TNG)** — play/pause, next/previous chapter, jump to any chapter (browse), volume, and put to sleep — live via the Tonie Cloud's real-time channel
+- 🎚️ **Live "now playing"** — current chapter title, progress bar and play/pause state
+- ⏲️ **Sleep timer** — start a timer via the `toniebox.sleeptimer` action, with a `sleeptimer_active` binary sensor
+- 📊 **Sensors** for chapter count, total duration, firmware version, online status, battery level, active figure and figure ID
+- 🔘 **Buttons** to sort (title / filename / date), shuffle, clear and refresh
+- 🔀 **Shuffle** the chapter order on demand (`sort_chapters` with `sort_by: random`) or automatically **on swap** — a per-Creative-Tonie switch that reshuffles a Tonie once a different one replaces it on a box
+- 🔴 **Binary Sensors** for transcoding, live mode, household lock, active figure and running sleep timer
 - 🎛️ **Switches** for LED, chapter skipping, scrubbing, offline mode, household lock
 - 🌐 **Select entities** for language, LED level, tap direction, age mode
-- ⚙️ **14 Services** for automations: sort, clear, rename, apply tune, redeem voucher and more
+- ⚙️ **Services** for automations: sleeptimer, sort, clear, rename, apply tune, redeem voucher and more
 - 🌍 **Translations** for English, German, French, Spanish and Italian
 - 🔐 Keycloak OpenID Connect authentication — same credentials as the Toniebox app
 - 🛠️ Config Flow setup — **no YAML required**
@@ -121,8 +125,9 @@ Each device appears under **Settings → Devices & Services → Toniebox** with 
 
 | Entity | Description |
 |---|---|
-| `media_player.<toniebox>` | Currently placed figure, cover image, playback position |
+| `media_player.<toniebox>` | Current chapter, cover, progress and play/pause; on TNG also play/pause, next/previous, chapter browsing, volume and sleep (turn off) |
 | `sensor.<toniebox>_current_tonie` | Currently placed figure (name) |
+| `sensor.<toniebox>_current_tonie_id` | Currently placed figure (raw Tonie ID — useful as an automation trigger) |
 | `sensor.<toniebox>_settings_applied` | Whether the latest settings have been transmitted |
 | `switch.<toniebox>_skip_chapters` | Chapter skipping via tap on/off |
 | `switch.<toniebox>_scrubbing` | Scrubbing by tilting on/off |
@@ -145,6 +150,7 @@ Each device appears under **Settings → Devices & Services → Toniebox** with 
 | `binary_sensor.<toniebox>_online` | Toniebox recently active (reachability) |
 | `binary_sensor.<toniebox>_led_active` | LED status |
 | `binary_sensor.<toniebox>_charging` | Currently charging — unknown when offline (TNG only) |
+| `binary_sensor.<toniebox>_sleeptimer_active` | Whether a sleep timer is running; `sleep_until` attribute shows when the box will sleep (TNG only) |
 | `select.<toniebox>_led_level` | LED brightness |
 | `select.<toniebox>_language` | Language setting |
 | `select.<toniebox>_tap_direction` | Tap direction |
@@ -165,6 +171,7 @@ Each device appears under **Settings → Devices & Services → Toniebox** with 
 | `sensor.<tonie>_transcoding` | Transcoding status |
 | `switch.<tonie>_private` | Hide Tonie from guest members |
 | `switch.<tonie>_live` | Enable live mode |
+| `switch.<tonie>_shuffle_on_swap` | **Local only** — when on, this Tonie's chapters are shuffled once it is replaced on a box by a *different* Tonie |
 | `binary_sensor.<tonie>_transcoding` | Transcoding in progress |
 | `binary_sensor.<tonie>_live` | Live status |
 | `binary_sensor.<tonie>_private` | Private status |
@@ -172,8 +179,14 @@ Each device appears under **Settings → Devices & Services → Toniebox** with 
 | `button.<tonie>_sort_by_title` | Sort chapters alphabetically |
 | `button.<tonie>_sort_by_filename` | Sort chapters by filename |
 | `button.<tonie>_sort_by_date` | Sort chapters by date |
+| `button.<tonie>_shuffle_chapters` | Shuffle chapters into a random order |
 | `button.<tonie>_refresh` | Reload Tonie data |
-| `select.<tonie>_sort_chapters` | Select and apply sort order |
+
+> **Shuffle on swap** (`switch.<tonie>_shuffle_on_swap`) is a local convenience toggle with no counterpart in the Tonie Cloud:
+> - Only a *displacement* counts: the shuffle fires for the Tonie that gets **replaced** on a box by a different Tonie. Simply lifting a Tonie off (box goes empty) never shuffles it, so you can pick it up and put it back later to keep listening where you left off.
+> - Only **Creative Tonies** with **≥ 2 chapters** are shuffled.
+> - Each shuffle triggers a full re-transcode on the Tonie Cloud (typically 1–60 s) — expected, not an error.
+> - Real-time on the Toniebox 2 (TNG) via the cloud's push channel; on classic (non-TNG) boxes there is currently no placement data source to detect a swap from, so this only works on TNG.
 
 ---
 
@@ -185,8 +198,10 @@ Each device appears under **Settings → Devices & Services → Toniebox** with 
 service: toniebox.sort_chapters
 data:
   entity_id: media_player.my_tonie
-  sort_by: title   # title | filename | date
+  sort_by: title   # title | filename | date | random
 ```
+
+> `random` shuffles the chapters into a new random order. Like every reorder, it triggers a full re-transcode of the Tonie on the Tonie Cloud (typically 1–60 s). Needs at least 2 chapters.
 
 ### `toniebox.clear_chapters` — Clear All Chapters
 
@@ -246,6 +261,22 @@ data:
   entity_id: media_player.my_toniebox
   name: "Kids Room"
 ```
+
+### `toniebox.sleeptimer` — Sleep Timer (Toniebox 2 / TNG only)
+
+Start a sleep timer: the box falls asleep on its own after the given number of
+minutes. Pass `0` to cancel a running timer.
+
+```yaml
+service: toniebox.sleeptimer
+data:
+  entity_id: media_player.my_toniebox
+  minutes: 30   # 0 = cancel the running timer
+```
+
+> Setting a timer has no immediate visible effect — the box keeps playing and
+> sleeps later. Watch `binary_sensor.<toniebox>_sleeptimer_active` (attribute
+> `sleep_until`) to confirm it is running.
 
 ### `toniebox.redeem_content_token` — Redeem Content Token
 
@@ -311,6 +342,35 @@ automation:
     - service: light.turn_on
       target:
         entity_id: light.kids_room
+```
+
+### Automatic sleep timer for a specific figure (TNG)
+
+Start a 60-minute sleep timer when a bedtime figure is placed, and cancel it
+when it is removed (uses the `current_tonie_id` sensor and `sleeptimer` action):
+
+```yaml
+automation:
+  alias: Toniebox - automatic sleep timer
+  triggers:
+    - trigger: state
+      entity_id: sensor.toniebox_current_tonie_id
+      to: "6B6A3428500304E0"          # bedtime figure -> start timer
+      id: figure_placed
+    - trigger: state
+      entity_id: sensor.toniebox_current_tonie_id
+      from: "6B6A3428500304E0"        # removed -> cancel timer
+      id: figure_removed
+  actions:
+    - choose:
+        - conditions: [{ condition: trigger, id: figure_placed }]
+          sequence:
+            - action: toniebox.sleeptimer
+              data: { entity_id: media_player.toniebox, minutes: 60 }
+        - conditions: [{ condition: trigger, id: figure_removed }]
+          sequence:
+            - action: toniebox.sleeptimer
+              data: { entity_id: media_player.toniebox, minutes: 0 }
 ```
 
 ### Volume 100% during the day, reduced to 50% at night
@@ -441,12 +501,16 @@ That means: it works — but **edge cases may occur**. PRs, bug reports and impr
 
 - 🧸 Jede **Creative Tonie** als eigenes Gerät mit Media Player, Cover-Bild und Kapitelliste
 - 📻 Jede **Toniebox** als eigenes Gerät — zeigt die aktuell aufgelegte Figur mit Name und Cover
-- 📊 **Sensoren** für Kapitelanzahl, Gesamtdauer, Firmware-Version, Online-Status, Batteriestand und aktive Box
-- 🔘 **Buttons** zum Sortieren (Titel / Dateiname / Datum), Leeren und Aktualisieren
-- 🔴 **Binary Sensors** für Transcoding, Live-Modus, Haushalt-Lock, aktive Figur
+- ▶️ **Volle Wiedergabesteuerung bei der Toniebox 2 (TNG)** — Play/Pause, Kapitel vor/zurück, zu beliebigem Kapitel springen (Browse), Lautstärke und Schlafenlegen — live über den Echtzeit-Kanal der Tonie Cloud
+- 🎚️ **Live „Now Playing"** — aktueller Kapiteltitel, Fortschrittsbalken und Play/Pause-Status
+- ⏲️ **Schlaftimer** — per Action `toniebox.sleeptimer` starten, mit Binary-Sensor `sleeptimer_active`
+- 📊 **Sensoren** für Kapitelanzahl, Gesamtdauer, Firmware-Version, Online-Status, Batteriestand, aktive Figur und Figur-ID
+- 🔘 **Buttons** zum Sortieren (Titel / Dateiname / Datum), Mischen, Leeren und Aktualisieren
+- 🔀 **Mischen** der Kapitelreihenfolge auf Wunsch (`sort_chapters` mit `sort_by: random`) oder automatisch **beim Wechsel** — ein Schalter pro Creative Tonie, der einen Tonie neu mischt, sobald er auf einer Box durch einen anderen ersetzt wird
+- 🔴 **Binary Sensors** für Transcoding, Live-Modus, Haushalt-Lock, aktive Figur und laufenden Schlaftimer
 - 🎛️ **Switches** für LED, Kapitel-Überspringen, Scrubbing, Offline-Modus, Haushalt-Sperren
 - 🌐 **Select-Entities** für Sprache, LED-Level, Tap-Richtung, Alters-Modus
-- ⚙️ **14 Services** für Automationen: sortieren, löschen, umbenennen, Tune aufspielen, Gutschein einlösen u.v.m.
+- ⚙️ **Services** für Automationen: Schlaftimer, sortieren, löschen, umbenennen, Tune aufspielen, Gutschein einlösen u.v.m.
 - 🌍 **Übersetzungen** für Deutsch, Englisch, Französisch, Spanisch und Italienisch
 - 🔐 Keycloak OpenID Connect Authentifizierung — selbe Zugangsdaten wie die Toniebox App
 - 🛠️ Config Flow Setup — **kein YAML erforderlich**
@@ -521,8 +585,9 @@ Jedes Gerät erscheint unter **Einstellungen → Geräte & Dienste → Toniebox*
 
 | Entity | Beschreibung |
 |---|---|
-| `media_player.<toniebox>` | Aktuell aufgelegte Figur, Cover-Bild, Wiedergabe-Position |
+| `media_player.<toniebox>` | Aktuelles Kapitel, Cover, Fortschritt und Play/Pause; bei TNG zusätzlich Play/Pause, Kapitel vor/zurück, Kapitel-Browse, Lautstärke und Schlafenlegen |
 | `sensor.<toniebox>_aktuelle_figur` | Aktuell aufgelegte Figur (Name) |
+| `sensor.<toniebox>_aktuelle_figur_id` | Aktuell aufgelegte Figur (rohe Tonie-ID — praktisch als Automations-Trigger) |
 | `sensor.<toniebox>_einstellungen_uebertragen` | Ob die aktuellen Einstellungen übertragen wurden |
 | `switch.<toniebox>_kapitel_ueberspringen` | Kapitel-Überspringen per Tippen ein/aus |
 | `switch.<toniebox>_vorspulen_zurueckspulen` | Scrubbing durch Kippen ein/aus |
@@ -545,6 +610,7 @@ Jedes Gerät erscheint unter **Einstellungen → Geräte & Dienste → Toniebox*
 | `binary_sensor.<toniebox>_online` | Toniebox zuletzt aktiv (Erreichbarkeit) |
 | `binary_sensor.<toniebox>_led_aktiv` | LED-Status |
 | `binary_sensor.<toniebox>_wird_geladen` | Wird gerade geladen — Unbekannt wenn offline (nur TNG) |
+| `binary_sensor.<toniebox>_schlaftimer_aktiv` | Ob ein Schlaftimer läuft; Attribut `sleep_until` zeigt die Einschlaf-Uhrzeit (nur TNG) |
 | `select.<toniebox>_led_level` | LED-Helligkeit |
 | `select.<toniebox>_sprache` | Spracheinstellung |
 | `select.<toniebox>_tap_richtung` | Tipp-Richtung |
@@ -565,6 +631,7 @@ Jedes Gerät erscheint unter **Einstellungen → Geräte & Dienste → Toniebox*
 | `sensor.<tonie>_transkodierung` | Transkodierungs-Status |
 | `switch.<tonie>_privat` | Tonie für Gastmitglieder ausblenden |
 | `switch.<tonie>_live` | Live-Modus aktivieren |
+| `switch.<tonie>_shuffle_on_swap` | **Nur lokal** — wenn aktiv, werden die Kapitel dieses Tonies gemischt, sobald er auf einer Box durch einen *anderen* Tonie ersetzt wird |
 | `binary_sensor.<tonie>_wird_verarbeitet` | Transkodierung läuft |
 | `binary_sensor.<tonie>_live` | Live-Status |
 | `binary_sensor.<tonie>_privat` | Privat-Status |
@@ -572,8 +639,14 @@ Jedes Gerät erscheint unter **Einstellungen → Geräte & Dienste → Toniebox*
 | `button.<tonie>_nach_titel_sortieren` | Kapitel alphabetisch sortieren |
 | `button.<tonie>_nach_dateiname_sortieren` | Kapitel nach Dateiname sortieren |
 | `button.<tonie>_nach_datum_sortieren` | Kapitel nach Datum sortieren |
+| `button.<tonie>_kapitel_mischen` | Kapitel in eine zufällige Reihenfolge mischen |
 | `button.<tonie>_aktualisieren` | Tonie-Daten neu laden |
-| `select.<tonie>_kapitel_sortieren` | Sortierart auswählen und anwenden |
+
+> **Beim Wechsel mischen** (`switch.<tonie>_shuffle_on_swap`) ist ein rein lokaler Schalter ohne Entsprechung in der Tonie Cloud:
+> - Nur die *Verdrängung* zählt: Gemischt wird der Tonie, der auf einer Box durch einen **anderen** Tonie ersetzt wird. Das bloße Abnehmen (Box wird leer) löst kein Mischen aus — so kannst du ihn abnehmen und später wieder auflegen, um weiterzuhören.
+> - Nur **Kreativ-Tonies** mit **≥ 2 Kapiteln** werden gemischt.
+> - Jedes Mischen löst ein vollständiges Neu-Transkodieren in der Tonie Cloud aus (typisch 1–60 s) — das ist normal, kein Fehler.
+> - In Echtzeit auf der Toniebox 2 (TNG) über den Push-Kanal der Cloud; auf klassischen (Nicht-TNG) Boxen gibt es aktuell keine Placement-Datenquelle, um einen Wechsel zu erkennen — funktioniert daher nur auf TNG.
 
 ---
 
@@ -585,8 +658,10 @@ Jedes Gerät erscheint unter **Einstellungen → Geräte & Dienste → Toniebox*
 service: toniebox.sort_chapters
 data:
   entity_id: media_player.mein_tonie
-  sort_by: title   # title | filename | date
+  sort_by: title   # title | filename | date | random
 ```
+
+> `random` mischt die Kapitel in eine neue zufällige Reihenfolge. Wie jede Umsortierung löst das ein vollständiges Neu-Transkodieren des Tonies in der Tonie Cloud aus (typisch 1–60 s). Es werden mindestens 2 Kapitel benötigt.
 
 ### `toniebox.clear_chapters` — Alle Kapitel löschen
 
@@ -646,6 +721,22 @@ data:
   entity_id: media_player.meine_toniebox
   name: "Kinderzimmer"
 ```
+
+### `toniebox.sleeptimer` — Schlaftimer (nur Toniebox 2 / TNG)
+
+Startet einen Schlaftimer: Die Box schläft nach der angegebenen Minutenzahl von
+selbst ein. Mit `0` wird ein laufender Timer abgebrochen.
+
+```yaml
+service: toniebox.sleeptimer
+data:
+  entity_id: media_player.meine_toniebox
+  minutes: 30   # 0 = laufenden Timer abbrechen
+```
+
+> Das Setzen eines Timers hat keinen sofort sichtbaren Effekt — die Box spielt
+> weiter und schläft erst später ein. Zur Kontrolle
+> `binary_sensor.<toniebox>_schlaftimer_aktiv` (Attribut `sleep_until`) beobachten.
 
 ### `toniebox.redeem_content_token` — Content Token einlösen
 
@@ -711,6 +802,36 @@ automation:
     - service: light.turn_on
       target:
         entity_id: light.kinderzimmer
+```
+
+### Automatischer Schlaftimer für eine bestimmte Figur (TNG)
+
+Startet beim Auflegen einer Einschlaf-Figur einen 60-Minuten-Timer und bricht
+ihn beim Hochnehmen ab (nutzt den `aktuelle_figur_id`-Sensor und die
+`sleeptimer`-Action):
+
+```yaml
+automation:
+  alias: Toniebox - Automatischer Schlaftimer
+  triggers:
+    - trigger: state
+      entity_id: sensor.toniebox_aktuelle_figur_id
+      to: "6B6A3428500304E0"          # Einschlaf-Figur -> Timer starten
+      id: figur_aufgelegt
+    - trigger: state
+      entity_id: sensor.toniebox_aktuelle_figur_id
+      from: "6B6A3428500304E0"        # entfernt -> Timer abbrechen
+      id: figur_entfernt
+  actions:
+    - choose:
+        - conditions: [{ condition: trigger, id: figur_aufgelegt }]
+          sequence:
+            - action: toniebox.sleeptimer
+              data: { entity_id: media_player.toniebox, minutes: 60 }
+        - conditions: [{ condition: trigger, id: figur_entfernt }]
+          sequence:
+            - action: toniebox.sleeptimer
+              data: { entity_id: media_player.toniebox, minutes: 0 }
 ```
 
 ### Lautstärke tagsüber 100 %, nachts auf 50 % reduzieren

--- a/custom_components/toniebox/__init__.py
+++ b/custom_components/toniebox/__init__.py
@@ -13,11 +13,16 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
     DOMAIN, CONF_USERNAME, CONF_PASSWORD, UPDATE_INTERVAL_MINUTES,
     ICI_TOPIC_BATTERY, ICI_TOPIC_ONLINE, ICI_TOPIC_HEADPHONES, ICI_TOPIC_SETTINGS,
+    ICI_TOPIC_PLAYBACK, ICI_TOPIC_VOLUME, ICI_TOPIC_BEDTIME,
+    ICI_CMD_PLAYBACK, ICI_CMD_VOLUME, ICI_VOLUME_MAX_LEVEL,
+    ICI_CMD_SLEEP_TIMER, ICI_CMD_SLEEP_NOW,
+    SORT_BY_RANDOM, STORAGE_VERSION, STORAGE_KEY_SHUFFLE,
 )
 from .ici_client import TonieboxIciClient
 from .tonie_client import TonieCloudClient, TonieCloudAuthError, TonieCloudAPIError
@@ -56,6 +61,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await coordinator.async_config_entry_first_refresh()
     except Exception as err:
         raise ConfigEntryNotReady(f"Could not fetch data: {err}") from err
+
+    # Load persisted "shuffle on swap" switch states before platforms are set up.
+    await coordinator.async_load_shuffle()
 
     # Start ICI real-time connection for TNG boxes
     await coordinator.async_start_ici()
@@ -109,6 +117,25 @@ async def _find_toniebox(hass: HomeAssistant, entity_id: str):
     return None, None, None
 
 
+async def _find_toniebox_target(hass: HomeAssistant, entity_id: str):
+    """Look up (coordinator, hh_id, tb_id, tb_dict) for any Toniebox entity.
+
+    Unlike _find_toniebox this returns the coordinator and the box data dict, so
+    callers can access the MAC / generation and invoke coordinator ICI commands.
+    """
+    registry = er.async_get(hass)
+    entry = registry.async_get(entity_id)
+    if entry is not None and entry.unique_id.startswith("tb_"):
+        uid = entry.unique_id[3:]  # strip "tb_"
+        for coordinator in hass.data.get(DOMAIN, {}).values():
+            for hh_id, hh in coordinator.data.get("households", {}).items():
+                for tb_id, tb in hh.get("tonieboxes", {}).items():
+                    if uid == tb_id or uid.startswith(tb_id + "_"):
+                        return coordinator, hh_id, tb_id, tb
+
+    return None, None, None, None
+
+
 def _slugify(text: str) -> str:
     import re
     text = text.lower().strip()
@@ -150,7 +177,7 @@ def _register_services(hass: HomeAssistant) -> None:
         DOMAIN, "sort_chapters", handle_sort_chapters,
         schema=vol.Schema({
             vol.Required("entity_id"): cv.string,
-            vol.Optional("sort_by", default="title"): vol.In(["title", "filename", "date"]),
+            vol.Optional("sort_by", default="title"): vol.In(["title", "filename", "date", "random"]),
         }),
     )
 
@@ -295,6 +322,34 @@ def _register_services(hass: HomeAssistant) -> None:
         }),
     )
 
+    async def handle_sleeptimer(call):
+        coordinator, hh_id, tb_id, tb = await _find_toniebox_target(
+            hass, call.data["entity_id"]
+        )
+        if not coordinator or not tb:
+            _LOGGER.error("sleeptimer: Toniebox not found for %s", call.data["entity_id"])
+            return
+        if tb.get("generation") != "tng":
+            _LOGGER.warning(
+                "sleeptimer: only supported on Toniebox 2 (TNG); %s is %s",
+                call.data["entity_id"], tb.get("generation"),
+            )
+            return
+        mac = tb.get("mac_address") or ""
+        minutes = call.data["minutes"]
+        if minutes <= 0:
+            coordinator.ici_cancel_sleep_timer(mac)
+        else:
+            coordinator.ici_set_sleep_timer(mac, minutes * 60)
+
+    hass.services.async_register(
+        DOMAIN, "sleeptimer", handle_sleeptimer,
+        schema=vol.Schema({
+            vol.Required("entity_id"): cv.string,
+            vol.Required("minutes"): vol.All(vol.Coerce(int), vol.Range(min=0)),
+        }),
+    )
+
     # ── Voucher service ───────────────────────────────────────────────────────
 
     async def handle_redeem_voucher(call):
@@ -363,11 +418,116 @@ class TonieboxDataUpdateCoordinator(DataUpdateCoordinator):
         self.entry = entry
         self.ici_client: TonieboxIciClient | None = None
         self._mac_to_tb: dict[str, tuple[str, str]] = {}  # mac → (hh_id, tb_id)
+        # ── Shuffle on swap ──
+        # Persisted per-Creative-Tonie toggle (tonie_id → bool).
+        self.shuffle_enabled: dict[str, bool] = {}
+        self._shuffle_store: Store | None = None
+        # Last placed tonie per box (box_id → tonie_id | None), tracked in memory
+        # to detect a *displacement* (one tonie replaced by a different one).
+        self._last_placed: dict[str, str | None] = {}
         super().__init__(
             hass, _LOGGER,
             name=DOMAIN,
             update_interval=timedelta(minutes=UPDATE_INTERVAL_MINUTES),
         )
+
+    # ── Shuffle on swap ────────────────────────────────────────────────────────
+
+    async def async_load_shuffle(self) -> None:
+        """Load persisted 'shuffle on swap' switch states from the Store."""
+        self._shuffle_store = Store(
+            self.hass, STORAGE_VERSION, f"{STORAGE_KEY_SHUFFLE}_{self.entry.entry_id}"
+        )
+        try:
+            stored = await self._shuffle_store.async_load()
+        except Exception:
+            _LOGGER.warning("Could not load shuffle-on-swap state", exc_info=True)
+            stored = None
+        enabled = (stored or {}).get("shuffleEnabled")
+        if isinstance(enabled, dict):
+            self.shuffle_enabled = {k: bool(v) for k, v in enabled.items()}
+
+    def is_shuffle_enabled(self, tonie_id: str) -> bool:
+        """Return True if 'shuffle on swap' is active for this Creative Tonie."""
+        return bool(self.shuffle_enabled.get(tonie_id))
+
+    async def async_set_shuffle_enabled(self, tonie_id: str, enabled: bool) -> None:
+        """Persist the 'shuffle on swap' toggle for a Creative Tonie."""
+        self.shuffle_enabled[tonie_id] = enabled
+        if self._shuffle_store:
+            self._shuffle_store.async_delay_save(
+                lambda: {"shuffleEnabled": self.shuffle_enabled}, 1
+            )
+
+    def _find_creative_tonie(self, tonie_id: str, data: dict) -> tuple[str | None, dict | None]:
+        """Return (household_id, tonie_dict) for a Creative Tonie id, or (None, None)."""
+        for hh_id, hh in (data or {}).get("households", {}).items():
+            tonie = hh.get("creativetonies", {}).get(tonie_id)
+            if tonie is not None:
+                return hh_id, tonie
+        return None, None
+
+    def _note_placement(self, tb_id: str, current_tonie_id: str | None, data: dict) -> None:
+        """Update last-placed tracking for a box and shuffle the displaced Tonie.
+
+        A shuffle is only triggered when a Creative Tonie with the switch enabled
+        (and ≥ 2 chapters) is replaced on a box by a *different* Tonie. Merely
+        removing a Tonie (box goes empty) never triggers a shuffle, so you can
+        pick a figure up and later put it back to continue where it left off.
+        """
+        old_tonie_id = self._last_placed.get(tb_id)
+        self._last_placed[tb_id] = current_tonie_id
+
+        if not current_tonie_id:
+            return  # box emptied → removal only, never a shuffle
+        if old_tonie_id is None:
+            return  # first placement seen for this box → no predecessor
+        if old_tonie_id == current_tonie_id:
+            return  # no real change
+        # old_tonie_id was displaced by a different tonie → maybe shuffle it
+        if not self.is_shuffle_enabled(old_tonie_id):
+            return
+        hh_id, tonie = self._find_creative_tonie(old_tonie_id, data)
+        if tonie is None:
+            return  # not a Creative Tonie (content tonies/discs can't be reordered)
+        chapter_count = tonie.get("chapter_count")
+        if chapter_count is None:
+            chapter_count = len(tonie.get("chapters", []))
+        if chapter_count < 2:
+            return
+        self.hass.async_create_task(self._async_shuffle_on_swap(hh_id, old_tonie_id))
+
+    def _process_placements(self, data: dict) -> None:
+        """Feed the current placement of every box into the swap detector."""
+        for hh in data.get("households", {}).values():
+            for tb_id, tb in hh.get("tonieboxes", {}).items():
+                placed = (tb.get("placement") or {}).get("tonie") or {}
+                tonie_id = placed.get("id") if isinstance(placed, dict) else None
+                self._note_placement(tb_id, tonie_id, data)
+
+    async def _async_shuffle_on_swap(self, hh_id: str, tonie_id: str) -> None:
+        """Shuffle a Creative Tonie's chapters after it was swapped out."""
+        # Re-check right before executing — state/content may have changed.
+        if not self.is_shuffle_enabled(tonie_id):
+            return
+        found_hh, tonie = self._find_creative_tonie(tonie_id, self.data or {})
+        hh_id = found_hh or hh_id
+        if tonie is None:
+            return
+        chapter_count = tonie.get("chapter_count")
+        if chapter_count is None:
+            chapter_count = len(tonie.get("chapters", []))
+        if chapter_count < 2:
+            return
+        try:
+            await self.client.sort_chapters(hh_id, tonie_id, SORT_BY_RANDOM)
+            _LOGGER.info(
+                "Auto-shuffled chapters of Creative Tonie %s after it was swapped out",
+                tonie_id,
+            )
+            await self.async_request_refresh()
+        except Exception as err:
+            _LOGGER.warning("Auto-shuffle failed for Creative Tonie %s: %s", tonie_id, err)
 
     async def async_start_ici(self) -> None:
         """Start ICI MQTT connection for real-time TNG box data."""
@@ -422,6 +582,42 @@ class TonieboxDataUpdateCoordinator(DataUpdateCoordinator):
         except Exception:
             _LOGGER.debug("Proactive token refresh after ICI auth failure failed", exc_info=True)
 
+    @staticmethod
+    def _parse_playback_state(payload: dict) -> dict:
+        """Derive a media-player-friendly live playback state from an ICI
+        playback/state payload.
+
+        chapterUntilMs is an absolute epoch-ms timestamp for when the current
+        chapter ends; combined with chapterDuration we compute the elapsed
+        position *at message-receipt time* and store updated_at, so Home
+        Assistant extrapolates the progress bar forward while playing and
+        freezes it while paused.
+        """
+        now = datetime.now(timezone.utc)
+        duration = payload.get("chapterDuration")
+        until_ms = payload.get("chapterUntilMs")
+        position_ms = payload.get("chapterPositionMs")
+        position = None
+        if isinstance(position_ms, (int, float)):
+            # Paused: box reports an exact position within the chapter.
+            position = position_ms / 1000
+            if isinstance(duration, (int, float)):
+                position = max(0.0, min(float(duration), position))
+        elif isinstance(duration, (int, float)) and isinstance(until_ms, (int, float)):
+            # Playing: derive elapsed from the chapter's absolute end timestamp.
+            remaining = until_ms / 1000 - now.timestamp()
+            position = max(0.0, min(float(duration), float(duration) - remaining))
+        return {
+            "paused": payload.get("paused"),
+            "ended": payload.get("ended"),
+            "blocked": payload.get("blocked"),
+            "downloading": payload.get("downloading"),
+            "chapter": payload.get("chapter"),
+            "chapter_duration": duration,
+            "position": position,
+            "updated_at": now,
+        }
+
     def _on_ici_message(self, mac: str, subtopic: str, payload: dict) -> None:
         """Handle an ICI MQTT message (called from the event loop)."""
         lookup_mac = mac.upper()
@@ -475,17 +671,123 @@ class TonieboxDataUpdateCoordinator(DataUpdateCoordinator):
             tb["settings_applied"] = True
             updated = True
 
+        elif subtopic == ICI_TOPIC_VOLUME and isinstance(payload, dict):
+            # Live playback volume: {"level": N, "hardwarePercentage": P}.
+            tb["volume"] = {
+                "level": payload.get("level"),
+                "hardware_percentage": payload.get("hardwarePercentage"),
+            }
+            updated = True
+
+        elif subtopic == ICI_TOPIC_BEDTIME:
+            # {"stl": {"state": "on"|"off"|"completed", "duration": <s>, "until": <epoch>}}
+            stl = payload.get("stl") if isinstance(payload, dict) else None
+            if isinstance(stl, dict):
+                tb["sleep_timer"] = {
+                    "state": stl.get("state"),
+                    "duration": stl.get("duration"),
+                    "until": stl.get("until"),
+                }
+            else:
+                tb["sleep_timer"] = {}
+            updated = True
+
+        elif subtopic == ICI_TOPIC_PLAYBACK:
+            # Verified against a live account: {"tonie": "<id>", "paused": bool,
+            # "chapter": int, "chapterUntilMs": <epoch ms>, "chapterDuration":
+            # <seconds>, "ended": bool, ...} — "tonie" is a flat ID string, not a
+            # nested object. An empty/None payload means the Tonie was removed.
+            if not payload:
+                tb["placement"] = {}
+                tb["playback_state"] = {}
+            elif isinstance(payload, dict):
+                raw_tonie = payload.get("tonie")
+                if isinstance(raw_tonie, dict):
+                    tonie = raw_tonie if raw_tonie.get("id") else None
+                elif isinstance(raw_tonie, str) and raw_tonie:
+                    tonie = {"id": raw_tonie}
+                else:
+                    flat_id = payload.get("tonieId") or payload.get("id")
+                    tonie = {"id": flat_id} if flat_id else None
+                tb["placement"] = {"tonie": tonie} if tonie else {}
+                tb["playback_state"] = self._parse_playback_state(payload)
+                # Real-time swap detection: shuffle a displaced Creative Tonie.
+                try:
+                    self._note_placement(
+                        tb_id, tonie.get("id") if tonie else None, data
+                    )
+                except Exception:
+                    _LOGGER.warning("Shuffle-on-swap push processing failed", exc_info=True)
+            updated = True
+            # MQTT gives us the identity of the placed Tonie immediately, but not
+            # chapters/cover art — request a full coordinator refresh so REST/
+            # GraphQL (get_playback_info) fills in the rest shortly after.
+            self.hass.async_create_task(self.async_request_refresh())
+
         if updated:
             tb["last_seen"] = datetime.now(timezone.utc)
             self.async_set_updated_data(data)
 
+    # ── ICI app-control commands (mirror the official Tonies app) ──────────────
+
+    def _ici_publish(self, mac: str, command_type: str, payload: dict) -> bool:
+        """Send an app-control command to a box via the ICI broker."""
+        if not self.ici_client or not mac:
+            _LOGGER.warning("Cannot send ICI command %s: no ICI client / MAC", command_type)
+            return False
+        # State topics are delivered on the upper-case MAC; commands use the same.
+        return self.ici_client.publish_command(mac.upper(), command_type, payload)
+
+    def ici_playback_command(
+        self, mac: str, action: str,
+        chapter: int | None = None, ms: int | None = None,
+    ) -> bool:
+        """Play/pause/seek. action = 'start' | 'pause' | 'setPosition'."""
+        payload: dict = {"action": action}
+        if chapter is not None:
+            payload["chapter"] = chapter
+        if ms is not None:
+            payload["ms"] = ms
+        return self._ici_publish(mac, ICI_CMD_PLAYBACK, payload)
+
+    def ici_set_volume_level(self, mac: str, level: int) -> bool:
+        """Set the playback volume by discrete level (clamped to the box scale)."""
+        level = max(0, min(ICI_VOLUME_MAX_LEVEL, int(level)))
+        return self._ici_publish(mac, ICI_CMD_VOLUME, {"level": level})
+
+    def ici_sleep_now(self, mac: str) -> bool:
+        """Put the box to sleep immediately (it goes offline).
+
+        Mirrors the official app: set a short sleep timer, then send `sleep`.
+        Waking the box back up over the cloud is not possible.
+        """
+        self._ici_publish(mac, ICI_CMD_SLEEP_TIMER, {"state": "on", "duration": 300})
+        return self._ici_publish(mac, ICI_CMD_SLEEP_NOW, {})
+
+    def ici_set_sleep_timer(self, mac: str, seconds: int) -> bool:
+        """Arm a sleep timer: the box falls asleep on its own after `seconds`."""
+        return self._ici_publish(
+            mac, ICI_CMD_SLEEP_TIMER, {"state": "on", "duration": int(seconds)}
+        )
+
+    def ici_cancel_sleep_timer(self, mac: str) -> bool:
+        """Cancel a running sleep timer."""
+        return self._ici_publish(mac, ICI_CMD_SLEEP_TIMER, {"state": "off"})
+
     async def _async_update_data(self) -> dict:
         try:
-            return await self._fetch_all()
+            result = await self._fetch_all()
         except TonieCloudAuthError as err:
             raise ConfigEntryAuthFailed(str(err)) from err
         except Exception as err:
             raise UpdateFailed(f"Tonie Cloud error: {err}") from err
+        # Detect Tonie swaps from the freshly polled placement and, if enabled,
+        # shuffle any displaced Creative Tonie. Never let this break the poll.
+        try:
+            self._process_placements(result)
+        except Exception:
+            _LOGGER.warning("Shuffle-on-swap poll processing failed", exc_info=True)
+        return result
 
     async def _fetch_all(self) -> dict:
         result: dict = {
@@ -635,10 +937,14 @@ class TonieboxDataUpdateCoordinator(DataUpdateCoordinator):
             # The REST list endpoints for content tonies and discs return 404, and
             # the Toniebox REST response contains no placement data.
             # All three are available via GraphQL at /v2/graphql.
-            gql_placements: dict[str, dict] = {}  # box_id → placement dict
             try:
                 # The GraphQL API uses Relay-style pagination: each "my*" query
                 # returns a Connection type with edges[].node instead of a plain list.
+                # Field names verified via schema introspection. Content tonies use
+                # `title` + `series { name }` (there is no `name`), `lock` (not
+                # `locked`), and `languageName`. Discs use `title`/`coverImageUrl`.
+                # The Toniebox node has NO `placement` field — placement comes from
+                # ICI (see _on_ici_message), so it is not queried here.
                 gql_resp = await self.client.graphql_query("""
                     {
                       myContentTonies {
@@ -646,10 +952,13 @@ class TonieboxDataUpdateCoordinator(DataUpdateCoordinator):
                           node {
                             id
                             householdId
-                            name
+                            title
                             imageUrl
-                            locked
-                            language
+                            coverUrl
+                            lock
+                            languageName
+                            salesId
+                            series { name }
                             chapters { id title seconds transcoding }
                           }
                         }
@@ -659,20 +968,12 @@ class TonieboxDataUpdateCoordinator(DataUpdateCoordinator):
                           node {
                             id
                             householdId
-                            name
-                            imageUrl
-                            locked
-                          }
-                        }
-                      }
-                      myTonieboxes {
-                        edges {
-                          node {
-                            id
-                            householdId
-                            placement {
-                              tonie { id name imageUrl type }
-                            }
+                            title
+                            coverImageUrl
+                            discImageUrl
+                            lock
+                            language
+                            salesId
                           }
                         }
                       }
@@ -709,20 +1010,24 @@ class TonieboxDataUpdateCoordinator(DataUpdateCoordinator):
                         for ch in (tonie.get("chapters") or [])
                         if isinstance(ch, dict)
                     ]
+                    series_name = (tonie.get("series") or {}).get("name")
                     hh_data["contenttonies"][t_id] = {
                         "id": t_id,
-                        "name": tonie.get("name") or t_id,
-                        "image_url": tonie.get("imageUrl"),
+                        # title is the specific content name (e.g. "Schlummerjaguar
+                        # - …"); series.name is the product line ("Schlummerbande").
+                        "name": tonie.get("title") or series_name or t_id,
+                        "series": series_name,
+                        "image_url": tonie.get("imageUrl") or tonie.get("coverUrl"),
                         "household_id": hh_id,
-                        "locked": tonie.get("locked", False),
-                        "language": tonie.get("language"),
+                        "locked": tonie.get("lock", False),
+                        "language": tonie.get("languageName"),
                         "chapters": chapters,
                         "chapter_count": len(chapters),
                         "total_seconds": sum(c["seconds"] for c in chapters),
                         "transcoding": False,
                         "transcoding_errors": [],
                         "tune_id": None,
-                        "sales_id": None,
+                        "sales_id": tonie.get("salesId"),
                         "item_id": None,
                         "toniebox_id": None,
                     }
@@ -736,23 +1041,15 @@ class TonieboxDataUpdateCoordinator(DataUpdateCoordinator):
                         continue
                     hh_data["discs"][d_id] = {
                         "id": d_id,
-                        "name": disc.get("name") or d_id,
-                        "image_url": disc.get("imageUrl"),
+                        "name": disc.get("title") or d_id,
+                        "image_url": disc.get("coverImageUrl") or disc.get("discImageUrl"),
                         "household_id": hh_id,
-                        "locked": disc.get("locked", False),
-                        "language": None,
-                        "sales_id": None,
+                        "locked": disc.get("lock", False),
+                        "language": disc.get("language"),
+                        "sales_id": disc.get("salesId"),
                         "item_id": None,
                         "toniebox_id": None,
                     }
-
-                # Placement data per Toniebox (applied after the REST loop)
-                for gql_box in _relay_nodes(gql_data.get("myTonieboxes")):
-                    if gql_box.get("householdId") != hh_id:
-                        continue
-                    b_id = gql_box.get("id", "")
-                    if b_id:
-                        gql_placements[b_id] = gql_box.get("placement") or {}
 
             except Exception as e:
                 _LOGGER.debug("GraphQL query failed for %s: %s", hh_id, e)
@@ -773,9 +1070,20 @@ class TonieboxDataUpdateCoordinator(DataUpdateCoordinator):
                     if not b_id:
                         continue
 
-                    # REST API does not include placement — use GraphQL data.
-                    # Fall back to whatever the REST response has (usually {}).
-                    placement = gql_placements.get(b_id) or box.get("placement") or {}
+                    # Previous coordinator data for this box — holds the ICI
+                    # real-time values (battery, online, placement) that REST/
+                    # GraphQL don't reliably provide.
+                    prev_tb = (
+                        (self.data or {})
+                        .get("households", {}).get(hh_id, {})
+                        .get("tonieboxes", {}).get(b_id, {})
+                    )
+
+                    # REST API does not include placement, and GraphQL has no
+                    # placement field on the Toniebox node. Fall back to the ICI
+                    # real-time placement (set by _on_ici_message) so the currently
+                    # placed Tonie survives a poll cycle instead of being wiped to {}.
+                    placement = box.get("placement") or prev_tb.get("placement") or {}
                     placed_tonie = placement.get("tonie") or {}
 
                     # Normalize: API may return tonieId/tonie_id/id flat instead of
@@ -895,12 +1203,8 @@ class TonieboxDataUpdateCoordinator(DataUpdateCoordinator):
                             placed_tonie["name"] = placed_tonie.get("name") or known.get("name")
                             placed_tonie["imageUrl"] = placed_tonie.get("imageUrl") or known.get("image_url")
 
-                    # Preserve ICI real-time data across REST polling
-                    prev_tb = (
-                        (self.data or {})
-                        .get("households", {}).get(hh_id, {})
-                        .get("tonieboxes", {}).get(b_id, {})
-                    )
+                    # Preserve ICI real-time online state across REST polling
+                    # (prev_tb was looked up above, before placement resolution).
                     ici_online = prev_tb.get("online_state")
                     rest_online = box.get("onlineState")
                     # Keep ICI value if REST returns "unsupported" or None
@@ -960,6 +1264,13 @@ class TonieboxDataUpdateCoordinator(DataUpdateCoordinator):
                         # Legacy / unchanged
                         "firmware": box.get("firmware", {}),
                         "placement": placement,
+                        # Live playback state from ICI (position/chapter/paused);
+                        # REST/GraphQL don't provide it, so carry it across polls.
+                        "playback_state": prev_tb.get("playback_state") or {},
+                        # Live playback volume from ICI (level/hardware %).
+                        "volume": prev_tb.get("volume") or {},
+                        # Live sleep-timer state from ICI (stl).
+                        "sleep_timer": prev_tb.get("sleep_timer") or {},
                         "extras": box.get("extras", {}),
                         "playback_info": playback_info,
                     }

--- a/custom_components/toniebox/binary_sensor.py
+++ b/custom_components/toniebox/binary_sensor.py
@@ -39,6 +39,7 @@ async def async_setup_entry(
             if tb.get("generation") == "tng":
                 entities.append(TonieboxChargingSensor(coordinator, hh_id, tb_id))
                 entities.append(HeadphonesConnectedSensor(coordinator, hh_id, tb_id))
+                entities.append(TonieboxSleepTimerActiveSensor(coordinator, hh_id, tb_id))
     # ── Content Tonie binary sensors ─────────────────────────────────────────
     for hh_id, hh in coordinator.data.get("households", {}).items():
         for ct_id in hh.get("contenttonies", {}):
@@ -184,6 +185,31 @@ class TonieboxChargingSensor(_TbBin):
         if isinstance(battery, dict):
             return battery.get("status") == "charging"
         return None
+
+
+class TonieboxSleepTimerActiveSensor(_TbBin):
+    """Whether a sleep timer is currently running on a TNG Toniebox (via ICI)."""
+
+    _attr_icon = "mdi:timer-outline"
+    _attr_translation_key = "sleeptimer_active"
+
+    def __init__(self, coordinator, hh_id, tb_id):
+        super().__init__(coordinator, hh_id, tb_id)
+        self._attr_unique_id = f"tb_{tb_id}_sleeptimer_active"
+
+    @property
+    def is_on(self) -> bool:
+        timer = self._tb.get("sleep_timer")
+        return isinstance(timer, dict) and timer.get("state") == "on"
+
+    @property
+    def extra_state_attributes(self):
+        timer = self._tb.get("sleep_timer") or {}
+        until = timer.get("until")
+        sleep_until = None
+        if timer.get("state") == "on" and isinstance(until, (int, float)):
+            sleep_until = datetime.fromtimestamp(until, tz=timezone.utc).isoformat()
+        return {"sleep_until": sleep_until, "duration_seconds": timer.get("duration")}
 
 
 class HeadphonesConnectedSensor(_TbBin):

--- a/custom_components/toniebox/button.py
+++ b/custom_components/toniebox/button.py
@@ -25,6 +25,7 @@ _TONIE_BUTTONS = [
     _BtnDesc(key="sort_title",    name="Sort by Title",        translation_key="sort_by_title",    icon="mdi:sort-alphabetical-ascending", action="sort", args={"sort_by": "title"}),
     _BtnDesc(key="sort_filename", name="Sort by Filename",     translation_key="sort_by_filename", icon="mdi:sort-variant",               action="sort", args={"sort_by": "filename"}),
     _BtnDesc(key="sort_date",     name="Sort by Date",         translation_key="sort_by_date",     icon="mdi:sort-calendar-ascending",    action="sort", args={"sort_by": "date"}),
+    _BtnDesc(key="sort_random",   name="Shuffle Chapters",     translation_key="sort_by_random",   icon="mdi:shuffle",                    action="sort", args={"sort_by": "random"}),
     _BtnDesc(key="refresh",       name="Refresh",              translation_key="refresh",          icon="mdi:refresh",                    action="refresh"),
 ]
 

--- a/custom_components/toniebox/const.py
+++ b/custom_components/toniebox/const.py
@@ -34,7 +34,15 @@ SERVICE_MOVE_CHAPTER = "move_chapter"
 SORT_BY_TITLE = "title"
 SORT_BY_FILENAME = "filename"
 SORT_BY_DATE = "date"
-SORT_OPTIONS = [SORT_BY_TITLE, SORT_BY_FILENAME, SORT_BY_DATE]
+SORT_BY_RANDOM = "random"
+SORT_OPTIONS = [SORT_BY_TITLE, SORT_BY_FILENAME, SORT_BY_DATE, SORT_BY_RANDOM]
+
+# ── Shuffle-on-swap ────────────────────────────────────────────────────────────
+# Local-only per-Creative-Tonie toggle: when the Tonie gets displaced on a box by
+# a *different* Tonie, its chapters are shuffled (sort_by="random"). The switch
+# state lives in a per-config-entry Store (no counterpart in the Tonie Cloud).
+STORAGE_VERSION = 1
+STORAGE_KEY_SHUFFLE = f"{DOMAIN}_shuffle"  # actual key gets the entry_id suffixed
 
 # ICI (MQTT v5 real-time push)
 ICI_HOST = "ici.tonie.cloud"
@@ -43,8 +51,26 @@ ICI_TOPIC_BATTERY = "metrics/battery"
 ICI_TOPIC_ONLINE = "online-state"
 ICI_TOPIC_HEADPHONES = "metrics/headphones"
 ICI_TOPIC_SETTINGS = "settings-applied"
-# Reported (unverified against a live account) to push Tonie placement /
-# playback events in real time. Subscribed for observation only for now —
-# see _on_message's debug log for the raw payload shape before wiring it
-# into any entity state.
+# Verified against a live account: {"tonie": "<id>", "paused": bool, "chapter":
+# int, "chapterUntilMs": <epoch ms>, "chapterDuration": <seconds>, "ended": bool,
+# ...}. "tonie" is a flat ID string, not a nested object. An empty/None payload
+# means the Tonie was removed from the box.
 ICI_TOPIC_PLAYBACK = "playback/state"
+# Live playback volume pushed by the box: {"level": N, "hardwarePercentage": P}
+ICI_TOPIC_VOLUME = "volume/state"
+# Box reply carrying the sleep-timer (stl) state:
+#   {"stl": {"state": "on"|"off"|"completed", "duration": <s>, "until": <epoch>}}
+ICI_TOPIC_BEDTIME = "app-reply/bedtime-state"
+
+# ── ICI app-control commands (published by us / the official app) ──────────────
+# Commands are published to: external/toniebox/{MAC}/app-control/{ICI_CMD_*}
+ICI_CMD_PLAYBACK = "playback"      # {"action": "start"|"pause"|"setPosition", ...}
+ICI_CMD_VOLUME = "volume"          # {"level": N}
+ICI_CMD_SLEEP_TIMER = "stl"        # {"state": "on"|"off", "duration": <seconds>}
+# Put the box to sleep NOW (it goes offline). The app sends stl(duration=300)
+# then sleep({}).
+ICI_CMD_SLEEP_NOW = "sleep"        # {}
+
+# Toniebox volume "level" scale used by app-control/volume. Observed mapping
+# (level -> hardware %): 1->5, 6->40, 7->50, 8->60. Extrapolated max for 100%.
+ICI_VOLUME_MAX_LEVEL = 13

--- a/custom_components/toniebox/ici_client.py
+++ b/custom_components/toniebox/ici_client.py
@@ -19,10 +19,12 @@ from .const import (
     ICI_HOST,
     ICI_PORT,
     ICI_TOPIC_BATTERY,
+    ICI_TOPIC_BEDTIME,
     ICI_TOPIC_HEADPHONES,
     ICI_TOPIC_ONLINE,
     ICI_TOPIC_PLAYBACK,
     ICI_TOPIC_SETTINGS,
+    ICI_TOPIC_VOLUME,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -33,8 +35,9 @@ _SUBSCRIBE_TOPICS = [
     ICI_TOPIC_ONLINE,
     ICI_TOPIC_HEADPHONES,
     ICI_TOPIC_SETTINGS,
-    # Observation only for now — see const.py note on ICI_TOPIC_PLAYBACK.
     ICI_TOPIC_PLAYBACK,
+    ICI_TOPIC_VOLUME,
+    ICI_TOPIC_BEDTIME,
 ]
 
 
@@ -144,6 +147,27 @@ class TonieboxIciClient:
                     await result
             except Exception:
                 _LOGGER.debug("ICI on_auth_failed callback raised", exc_info=True)
+
+    def publish_command(self, mac: str, command_type: str, payload: dict[str, Any]) -> bool:
+        """Publish an app-control command to a Toniebox (QoS 1).
+
+        Mirrors what the official Tonies app sends. Topic:
+            external/toniebox/{MAC}/app-control/{command_type}
+        The MAC must match the case used for subscriptions (upper-case, as the
+        broker delivers state topics on the upper-case MAC). Returns True if the
+        publish was handed to paho, False if we're not connected.
+        """
+        if not self._client or not self._connected:
+            _LOGGER.warning("ICI not connected — cannot send command %s", command_type)
+            return False
+        topic = f"external/toniebox/{mac}/app-control/{command_type}"
+        try:
+            info = self._client.publish(topic, json.dumps(payload), qos=1)
+            _LOGGER.debug("ICI PUBLISH %s: %s (rc=%s)", topic, payload, info.rc)
+            return info.rc == mqtt.MQTT_ERR_SUCCESS
+        except Exception:
+            _LOGGER.warning("Failed to publish ICI command to %s", topic, exc_info=True)
+            return False
 
     async def reconnect(self, new_token: str) -> None:
         """Reconnect with a new access token."""

--- a/custom_components/toniebox/manifest.json
+++ b/custom_components/toniebox/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/git4sim/HA-Toniebox/issues",
   "requirements": ["paho-mqtt>=2.0"],
-  "version": "3.7.11"
+  "version": "3.7.12"
 }

--- a/custom_components/toniebox/media_player.py
+++ b/custom_components/toniebox/media_player.py
@@ -5,6 +5,8 @@ import logging
 from typing import Any
 
 from homeassistant.components.media_player import (
+    BrowseMedia,
+    MediaClass,
     MediaPlayerEntity,
     MediaPlayerEntityFeature,
     MediaPlayerState,
@@ -14,9 +16,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util import dt as dt_util
 
-from .const import DOMAIN
+from .const import DOMAIN, ICI_VOLUME_MAX_LEVEL
 from .device_info import creative_tonie_device_info, toniebox_device_info
 
 _LOGGER = logging.getLogger(__name__)
@@ -136,7 +137,26 @@ class TonieboxPlayer(CoordinatorEntity, MediaPlayerEntity):
     _attr_has_entity_name = True
     _attr_name = None
     _attr_media_content_type = MediaType.MUSIC
-    _attr_supported_features = MediaPlayerEntityFeature.BROWSE_MEDIA
+
+    # Live playback control (play/pause/skip/volume) works only over ICI, which
+    # is exclusive to the Toniebox 2 (TNG). Classic boxes get no controls.
+    _TNG_FEATURES = (
+        MediaPlayerEntityFeature.PLAY
+        | MediaPlayerEntityFeature.PAUSE
+        | MediaPlayerEntityFeature.NEXT_TRACK
+        | MediaPlayerEntityFeature.PREVIOUS_TRACK
+        | MediaPlayerEntityFeature.VOLUME_SET
+        | MediaPlayerEntityFeature.VOLUME_STEP
+        # TURN_OFF = put to sleep. TURN_ON = resume playback (the box cannot be
+        # woken from sleep over the cloud, so it is a no-op while offline). Both
+        # are advertised so media_player.toggle works — the toggle service
+        # requires TURN_ON and TURN_OFF together (used by e.g. Bubble Card).
+        | MediaPlayerEntityFeature.TURN_OFF
+        | MediaPlayerEntityFeature.TURN_ON
+        # Browse the placed Tonie's chapters and jump to any of them.
+        | MediaPlayerEntityFeature.BROWSE_MEDIA
+        | MediaPlayerEntityFeature.PLAY_MEDIA
+    )
 
     def __init__(self, coordinator, hh_id: str, tb_id: str) -> None:
         super().__init__(coordinator)
@@ -153,6 +173,20 @@ class TonieboxPlayer(CoordinatorEntity, MediaPlayerEntity):
         )
 
     @property
+    def _is_tng(self) -> bool:
+        return self._tb.get("generation") == "tng"
+
+    @property
+    def supported_features(self) -> MediaPlayerEntityFeature:
+        # Only the TNG (Toniebox 2) can be controlled remotely; a classic
+        # Toniebox 1 has no ICI connection, so it stays a display-only player.
+        return self._TNG_FEATURES if self._is_tng else MediaPlayerEntityFeature(0)
+
+    @property
+    def _mac(self) -> str:
+        return self._tb.get("mac_address") or ""
+
+    @property
     def device_info(self) -> dict:
         return toniebox_device_info(self.coordinator, self._hh_id, self._tb_id)
 
@@ -162,38 +196,90 @@ class TonieboxPlayer(CoordinatorEntity, MediaPlayerEntity):
 
     def _resolve_tonie_name(self, tonie_id: str) -> str | None:
         """Look up tonie name from known creative/content tonies by ID."""
+        known = self._known_tonie(tonie_id)
+        return known.get("name") if known else None
+
+    def _known_tonie(self, tonie_id: str) -> dict | None:
+        """The full known record (with chapters) for a tonie ID, if any."""
         hh = self.coordinator.data.get("households", {}).get(self._hh_id, {})
-        known = (
+        return (
             hh.get("creativetonies", {}).get(tonie_id)
             or hh.get("contenttonies", {}).get(tonie_id)
             or hh.get("discs", {}).get(tonie_id)
         )
-        return known.get("name") if known else None
+
+    @property
+    def _playback_state(self) -> dict:
+        """Live playback state pushed via ICI (position/chapter/paused)."""
+        return self._tb.get("playback_state") or {}
+
+    def _chapters(self) -> list[dict]:
+        """Chapter list of the currently placed Tonie (each a dict with a title).
+
+        Prefers the box's playback_info, falls back to the known tonie record
+        (creative tonies carry their own chapter list).
+        """
+        info = self._tb.get("playback_info", {})
+        chapters = info.get("chapters")
+        if not chapters:
+            known = self._known_tonie(self._placed_tonie().get("id", ""))
+            chapters = known.get("chapters") if known else None
+        return [c for c in (chapters or []) if isinstance(c, dict)]
+
+    def _chapter_title(self) -> str | None:
+        """Resolve the title of the currently playing chapter.
+
+        The box's `chapter` field is a 0-based index into the chapter list
+        (setPosition N -> plays list[N]).
+        """
+        chapter = self._playback_state.get("chapter")
+        if not isinstance(chapter, int) or chapter < 0:
+            return None
+        chapters = self._chapters()
+        if 0 <= chapter < len(chapters):
+            ch = chapters[chapter]
+            return ch.get("title") or ch.get("tuneTitle")
+        return None
 
     @property
     def state(self) -> MediaPlayerState:
-        if self._placed_tonie():
-            return MediaPlayerState.PLAYING
-        return MediaPlayerState.ON if self._tb.get("last_seen") else MediaPlayerState.OFF
+        # A box that is offline (e.g. put to sleep) reads as OFF.
+        if self._tb.get("online_state") == "offline":
+            return MediaPlayerState.OFF
+        if not self._placed_tonie():
+            return MediaPlayerState.ON if self._tb.get("last_seen") else MediaPlayerState.OFF
+        ps = self._playback_state
+        if ps.get("ended"):
+            return MediaPlayerState.IDLE
+        if ps.get("paused"):
+            return MediaPlayerState.PAUSED
+        return MediaPlayerState.PLAYING
 
     @property
     def media_title(self) -> str | None:
+        """Main line: the current chapter (what's playing right now)."""
         tonie = self._placed_tonie()
         if not tonie:
             return "Kein Tonie aufgelegt"
-        # Show chapter title from playback info if available
-        info = self._tb.get("playback_info", {})
-        chapter_title = info.get("chapterTitle") or info.get("chapter_title")
-        tonie_id = tonie.get("id", "")
-        tonie_name = (
-            tonie.get("name")
-            or self._resolve_tonie_name(tonie_id)
-            or tonie_id
-            or "Tonie aufgelegt"
-        )
+        chapter_title = self._chapter_title()
         if chapter_title:
-            return f"{tonie_name} – {chapter_title}"
-        return tonie_name
+            return chapter_title
+        chapter = self._playback_state.get("chapter")
+        if isinstance(chapter, int) and chapter >= 0:
+            # chapter is 0-based; show a human-friendly 1-based number.
+            return f"Kapitel {chapter + 1}"
+        # No live chapter info yet — fall back to the tonie's own name.
+        tonie_id = tonie.get("id", "")
+        return tonie.get("name") or self._resolve_tonie_name(tonie_id) or tonie_id
+
+    @property
+    def media_artist(self) -> str | None:
+        """Secondary line: the Tonie figure name (e.g. 'Rubie')."""
+        tonie = self._placed_tonie()
+        if not tonie:
+            return None
+        tonie_id = tonie.get("id", "")
+        return tonie.get("name") or self._resolve_tonie_name(tonie_id) or None
 
     @property
     def media_image_url(self) -> str | None:
@@ -206,29 +292,160 @@ class TonieboxPlayer(CoordinatorEntity, MediaPlayerEntity):
 
     @property
     def media_position(self) -> int | None:
-        """Current playback position in seconds."""
-        info = self._tb.get("playback_info", {})
-        pos = info.get("elapsed") or info.get("position") or info.get("progressInSeconds")
-        return int(pos) if pos is not None else None
+        """Elapsed seconds within the current chapter (from ICI live state)."""
+        pos = self._playback_state.get("position")
+        return int(pos) if isinstance(pos, (int, float)) else None
 
     @property
     def media_duration(self) -> int | None:
-        """Total duration of current track in seconds."""
-        info = self._tb.get("playback_info", {})
-        dur = info.get("duration") or info.get("totalSeconds") or info.get("durationInSeconds")
-        return int(dur) if dur is not None else None
+        """Duration of the current chapter in seconds (from ICI live state)."""
+        dur = self._playback_state.get("chapter_duration")
+        return int(dur) if isinstance(dur, (int, float)) else None
 
     @property
     def media_position_updated_at(self):
-        """Timestamp of last position update — set to now if position is known."""
-        if self.media_position is not None:
-            return dt_util.utcnow()
+        """When media_position was last measured — lets HA extrapolate the bar."""
+        return self._playback_state.get("updated_at")
+
+    # ── Volume ────────────────────────────────────────────────────────────────
+
+    @property
+    def _volume(self) -> dict:
+        return self._tb.get("volume") or {}
+
+    @property
+    def volume_level(self) -> float | None:
+        """Current playback volume as 0.0–1.0 (from the box's live hardware %)."""
+        pct = self._volume.get("hardware_percentage")
+        if isinstance(pct, (int, float)):
+            return max(0.0, min(1.0, pct / 100))
+        level = self._volume.get("level")
+        if isinstance(level, (int, float)):
+            return max(0.0, min(1.0, level / ICI_VOLUME_MAX_LEVEL))
         return None
+
+    # ── Controls (published to the ICI broker, mirroring the Tonies app) ───────
+
+    async def async_media_play(self) -> None:
+        if self._is_tng:
+            self.coordinator.ici_playback_command(self._mac, "start")
+
+    async def async_media_pause(self) -> None:
+        if self._is_tng:
+            self.coordinator.ici_playback_command(self._mac, "pause")
+
+    async def async_media_next_track(self) -> None:
+        if not self._is_tng:
+            return
+        chapter = self._playback_state.get("chapter")
+        if isinstance(chapter, int):
+            self.coordinator.ici_playback_command(
+                self._mac, "setPosition", chapter=chapter + 1, ms=0
+            )
+
+    async def async_media_previous_track(self) -> None:
+        if not self._is_tng:
+            return
+        chapter = self._playback_state.get("chapter")
+        # chapter is 0-based; chapter 0 is the first, so guard at >= 1.
+        if isinstance(chapter, int) and chapter >= 1:
+            self.coordinator.ici_playback_command(
+                self._mac, "setPosition", chapter=chapter - 1, ms=0
+            )
+
+    async def async_set_volume_level(self, volume: float) -> None:
+        if not self._is_tng:
+            return
+        level = round(volume * ICI_VOLUME_MAX_LEVEL)
+        self.coordinator.ici_set_volume_level(self._mac, level)
+
+    async def async_volume_up(self) -> None:
+        if not self._is_tng:
+            return
+        current = self._volume.get("level")
+        base = current if isinstance(current, int) else 0
+        self.coordinator.ici_set_volume_level(self._mac, base + 1)
+
+    async def async_volume_down(self) -> None:
+        if not self._is_tng:
+            return
+        current = self._volume.get("level")
+        base = current if isinstance(current, int) else 1
+        self.coordinator.ici_set_volume_level(self._mac, base - 1)
+
+    async def async_turn_off(self) -> None:
+        """Put the Toniebox to sleep (it goes offline)."""
+        if self._is_tng:
+            self.coordinator.ici_sleep_now(self._mac)
+
+    async def async_turn_on(self) -> None:
+        """Resume playback ('on'). The box can't be woken from sleep over the
+        cloud, so this only has an effect while it is awake; it exists mainly so
+        media_player.toggle is available (that service needs TURN_ON+TURN_OFF)."""
+        if self._is_tng:
+            self.coordinator.ici_playback_command(self._mac, "start")
+
+    # ── Chapter browsing / jumping ─────────────────────────────────────────────
+
+    async def async_browse_media(
+        self, media_content_type: str | None = None, media_content_id: str | None = None
+    ) -> BrowseMedia:
+        """Expose the placed Tonie's chapters as a browsable list.
+
+        The box addresses chapters 0-based, so the media_content_id carries the
+        0-based index while the label shows a human-friendly 1-based number.
+        """
+        current = self._playback_state.get("chapter")   # 0-based box index
+        children = []
+        for idx, ch in enumerate(self._chapters()):     # idx = 0-based box index
+            title = ch.get("title") or ch.get("tuneTitle") or f"Kapitel {idx + 1}"
+            # Mark the chapter that is playing right now.
+            label = f"▶ {title}" if idx == current else title
+            children.append(
+                BrowseMedia(
+                    title=label,
+                    media_class=MediaClass.TRACK,
+                    media_content_type=MediaType.MUSIC,
+                    media_content_id=f"chapter:{idx}",
+                    can_play=True,
+                    can_expand=False,
+                )
+            )
+        tonie = self._placed_tonie()
+        return BrowseMedia(
+            title=tonie.get("name") or "Kapitel",
+            media_class=MediaClass.DIRECTORY,
+            media_content_type="chapters",
+            media_content_id="chapters",
+            can_play=False,
+            can_expand=True,
+            children=children,
+            children_media_class=MediaClass.TRACK,
+        )
+
+    async def async_play_media(
+        self, media_type: str, media_id: str, **kwargs: Any
+    ) -> None:
+        """Jump to a chapter selected from the browse list (media_id 'chapter:N').
+
+        N is the box's 0-based chapter index (see async_browse_media).
+        """
+        if not self._is_tng or not media_id.startswith("chapter:"):
+            return
+        try:
+            chapter = int(media_id.split(":", 1)[1])
+        except ValueError:
+            return
+        if chapter >= 0:
+            self.coordinator.ici_playback_command(
+                self._mac, "setPosition", chapter=chapter, ms=0
+            )
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         tb = self._tb
         info = tb.get("playback_info", {})
+        ps = tb.get("playback_state") or {}
         attrs: dict[str, Any] = {
             "household_id": self._hh_id,
             "toniebox_id": self._tb_id,
@@ -237,6 +454,11 @@ class TonieboxPlayer(CoordinatorEntity, MediaPlayerEntity):
             "last_seen": tb.get("last_seen"),
             "firmware": tb.get("firmware", {}),
             "placement": tb.get("placement") or {},
+            # 1-based for humans; the box reports a 0-based chapter internally.
+            "current_chapter": (
+                ps["chapter"] + 1 if isinstance(ps.get("chapter"), int) else None
+            ),
+            "paused": ps.get("paused"),
         }
         if info:
             attrs["playback_info"] = info

--- a/custom_components/toniebox/select.py
+++ b/custom_components/toniebox/select.py
@@ -1,4 +1,4 @@
-"""Select platform — enum settings for Tonieboxes + sort selector for Creative Tonies."""
+"""Select platform — enum settings for Tonieboxes + language select for Content Tonies."""
 from __future__ import annotations
 
 import logging
@@ -10,9 +10,9 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, SORT_OPTIONS, SORT_BY_TITLE
+from .const import DOMAIN
 from .content_tonie import ContentTonieLanguageSelect
-from .device_info import creative_tonie_device_info, toniebox_device_info
+from .device_info import toniebox_device_info
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -106,10 +106,6 @@ async def async_setup_entry(
                     continue
                 entities.append(TonieboxSelect(coordinator, hh_id, tb_id, desc))
 
-        # Creative Tonie: sort selector
-        for t_id in hh.get("creativetonies", {}):
-            entities.append(TonieSortSelect(coordinator, hh_id, t_id))
-
     # ── Content Tonie selects ─────────────────────────────────────────────────
     for hh_id, hh in coordinator.data.get("households", {}).items():
         for ct_id in hh.get("contenttonies", {}):
@@ -187,33 +183,4 @@ class TonieboxSelect(CoordinatorEntity, SelectEntity):
         await self.coordinator.client.patch_toniebox(
             self._hh_id, self._tb_id, {self._desc.api_key: option}
         )
-        await self.coordinator.async_request_refresh()
-
-
-# ── Creative Tonie sort selector ──────────────────────────────────────────────
-
-class TonieSortSelect(CoordinatorEntity, SelectEntity):
-    _attr_has_entity_name = True
-    _attr_options = SORT_OPTIONS
-    _attr_icon = "mdi:sort"
-    _attr_translation_key = "sort_select"
-
-    def __init__(self, coordinator, hh_id: str, t_id: str) -> None:
-        super().__init__(coordinator)
-        self._hh_id = hh_id
-        self._t_id = t_id
-        self._current = SORT_BY_TITLE
-        self._attr_unique_id = f"ct_{t_id}_sort_select"
-
-    @property
-    def device_info(self) -> dict:
-        return creative_tonie_device_info(self.coordinator, self._hh_id, self._t_id)
-
-    @property
-    def current_option(self) -> str:
-        return self._current
-
-    async def async_select_option(self, option: str) -> None:
-        self._current = option
-        await self.coordinator.client.sort_chapters(self._hh_id, self._t_id, option)
         await self.coordinator.async_request_refresh()

--- a/custom_components/toniebox/sensor.py
+++ b/custom_components/toniebox/sensor.py
@@ -53,6 +53,7 @@ async def async_setup_entry(
             features = tb.get("features", [])
             entities += [
                 TonieboxCurrentTonieSensor(coordinator, hh_id, tb_id),
+                TonieboxCurrentTonieIdSensor(coordinator, hh_id, tb_id),
                 TonieboxFirmwareSensor(coordinator, hh_id, tb_id),
                 TonieboxLastSeenSensor(coordinator, hh_id, tb_id),
                 TonieboxOnlineStateSensor(coordinator, hh_id, tb_id),
@@ -827,11 +828,12 @@ class TonieboxCurrentTonieSensor(_TbBase):
         pi = self._playback
         # API: series = public Tonie character name (e.g. "Benjamin Blümchen")
         #      title  = content title (e.g. "Benjamin Blümchen und der Weihnachtsmann")
+        # Deliberately no ID fallback — the name belongs here; the raw ID is
+        # exposed by the separate TonieboxCurrentTonieIdSensor.
         return (
             pi.get("series")
             or tonie.get("name")
             or pi.get("title")
-            or tonie.get("id")
             or None
         )
 
@@ -865,3 +867,22 @@ class TonieboxCurrentTonieSensor(_TbBase):
                 for c in pi.get("chapters", [])
             ],
         }
+
+
+class TonieboxCurrentTonieIdSensor(TonieboxCurrentTonieSensor):
+    """The ID of the Tonie currently placed on the box (raw, unresolved)."""
+    _attr_translation_key = "current_tonie_id"
+    _attr_icon = "mdi:identifier"
+
+    def __init__(self, coordinator, hh_id, tb_id):
+        super().__init__(coordinator, hh_id, tb_id)
+        self._attr_unique_id = f"tb_{tb_id}_current_tonie_id"
+
+    @property
+    def native_value(self) -> str | None:
+        return self._placed_tonie.get("id") or None
+
+    @property
+    def entity_picture(self) -> str | None:
+        # The ID sensor is text-only; no cover art.
+        return None

--- a/custom_components/toniebox/services.yaml
+++ b/custom_components/toniebox/services.yaml
@@ -23,7 +23,7 @@ sort_chapters:
           domain: media_player
     sort_by:
       name: Sort By
-      description: Sort chapters by title, filename, or date.
+      description: Sort chapters by title, filename or date, or "random" to shuffle them into a new random order.
       default: title
       selector:
         select:
@@ -31,6 +31,7 @@ sort_chapters:
             - title
             - filename
             - date
+            - random
 
 remove_chapter:
   name: Remove Chapter
@@ -140,6 +141,32 @@ rename_toniebox:
       required: true
       selector:
         text:
+
+sleeptimer:
+  name: Sleep Timer
+  description: >
+    Start a sleep timer on a Toniebox 2 (TNG). The box falls asleep on its own
+    after the given number of minutes. Pass 0 minutes to cancel a running timer.
+  fields:
+    entity_id:
+      name: Toniebox
+      description: The media_player entity of the target Toniebox 2.
+      required: true
+      selector:
+        entity:
+          integration: toniebox
+          domain: media_player
+    minutes:
+      name: Minutes
+      description: Minutes until the box sleeps. 0 cancels the running timer.
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 1440
+          step: 1
+          unit_of_measurement: min
+          mode: box
 
 redeem_content_token:
   name: Redeem Content Token

--- a/custom_components/toniebox/strings.json
+++ b/custom_components/toniebox/strings.json
@@ -41,7 +41,7 @@
       "description": "Sort the chapters on a Creative Tonie.",
       "fields": {
         "entity_id": { "name": "Creative Tonie", "description": "The media_player entity of the target creative tonie." },
-        "sort_by": { "name": "Sort By", "description": "Sort chapters by: title, filename, or date." }
+        "sort_by": { "name": "Sort By", "description": "Sort chapters by: title, filename, date, or random (shuffle into a new random order)." }
       }
     },
     "remove_chapter": {
@@ -138,6 +138,7 @@
   "entity": {
     "sensor": {
       "current_tonie": {"name": "Current Figure"},
+      "current_tonie_id": {"name": "Current Figure ID"},
       "account": {"name": "Account"},
       "tonies": {"name": "Creative Tonies"},
       "content_tonies": {"name": "Content Tonies"},
@@ -197,8 +198,7 @@
       "language": {
         "name": "Box Language",
         "state": {"de": "German", "en": "English", "en-us": "English (US)", "fr": "French"}
-      },
-      "sort_select": {"name": "Sort Chapters"}
+      }
     },
     "switch": {
       "skipping": {"name": "Skip with Ear Press"},
@@ -207,6 +207,7 @@
       "accelerometer": {"name": "Tilt & Tap"},
       "private": {"name": "Play in This Household Only"},
       "live": {"name": "Live Mode"},
+      "shuffle_on_swap": {"name": "Shuffle on swap"},
       "lock_household": {"name": "Lock to Household"}
     },
     "button": {
@@ -215,6 +216,7 @@
       "sort_by_title": {"name": "Sort by Title"},
       "sort_by_filename": {"name": "Sort by Filename"},
       "sort_by_date": {"name": "Sort by Date"},
+      "sort_by_random": {"name": "Shuffle Chapters"},
       "refresh": {"name": "Refresh"},
       "factory_reset": {"name": "Factory Reset"},
       "remove_tune": {"name": "Remove Tune"}
@@ -229,7 +231,8 @@
       "locked_household": {"name": "Locked to Household"},
       "transcoding_active": {"name": "Transcoding Active"},
       "charging": {"name": "Charging"},
-      "headphones_connected": {"name": "Connected"}
+      "headphones_connected": {"name": "Connected"},
+      "sleeptimer_active": {"name": "Sleep Timer Active"}
     }
   }
 }

--- a/custom_components/toniebox/switch.py
+++ b/custom_components/toniebox/switch.py
@@ -41,6 +41,7 @@ async def async_setup_entry(
             entities += [
                 ToniePrivateSwitch(coordinator, hh_id, t_id),
                 TonieLiveSwitch(coordinator, hh_id, t_id),
+                TonieShuffleOnSwapSwitch(coordinator, hh_id, t_id),
             ]
 
     # ── Content Tonie switches ────────────────────────────────────────────────
@@ -302,3 +303,30 @@ class TonieLiveSwitch(_TonieSwitch):
         self._optimistic_state = False
         self.async_write_ha_state()
         await self._patch({"live": False})
+
+
+class TonieShuffleOnSwapSwitch(_TonieSwitch):
+    """Auto-shuffle this Tonie's chapters when a *different* Tonie replaces it on a box.
+
+    Local-only: unlike the Private/Live switches this has no counterpart in the
+    Tonie Cloud. The state is persisted in the integration's local Store and the
+    swap detection/shuffle happens in the coordinator (see __init__.py).
+    """
+    _attr_icon = "mdi:shuffle-variant"
+
+    def __init__(self, coordinator, hh_id, t_id):
+        super().__init__(coordinator, hh_id, t_id)
+        self._attr_unique_id = f"ct_{t_id}_shuffle_on_swap"
+        self._attr_translation_key = "shuffle_on_swap"
+
+    @property
+    def is_on(self) -> bool:
+        return self.coordinator.is_shuffle_enabled(self._t_id)
+
+    async def async_turn_on(self, **kw):
+        await self.coordinator.async_set_shuffle_enabled(self._t_id, True)
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kw):
+        await self.coordinator.async_set_shuffle_enabled(self._t_id, False)
+        self.async_write_ha_state()

--- a/custom_components/toniebox/tonie_client.py
+++ b/custom_components/toniebox/tonie_client.py
@@ -12,6 +12,7 @@ API Base: https://api.prod.tcs.toys/v2
 from __future__ import annotations
 
 import logging
+import random
 import time
 from typing import Any
 
@@ -589,7 +590,11 @@ class TonieCloudClient:
     # ── Chapter helpers ───────────────────────────────────────────────────────
 
     async def sort_chapters(self, household_id: str, tonie_id: str, sort_by: str = "title") -> None:
-        """Sort chapters on a creative tonie."""
+        """Sort chapters on a creative tonie.
+
+        sort_by "random" shuffles the chapters into a new random order (this
+        triggers a full re-transcode of the tonie on the Tonie Cloud).
+        """
         tonie = await self.get_creative_tonie(household_id, tonie_id)
         chapters = tonie.get("chapters", [])
         if sort_by == "title":
@@ -598,6 +603,11 @@ class TonieCloudClient:
             chapters.sort(key=lambda c: c.get("file", c.get("title", "")).lower())
         elif sort_by == "date":
             chapters.sort(key=lambda c: c.get("id", ""))
+        elif sort_by == "random":
+            # Nothing to shuffle with fewer than 2 chapters.
+            if len(chapters) < 2:
+                return
+            random.shuffle(chapters)
         await self.patch_creative_tonie(household_id, tonie_id, {"chapters": chapters})
 
     async def clear_chapters(self, household_id: str, tonie_id: str) -> None:

--- a/custom_components/toniebox/translations/de.json
+++ b/custom_components/toniebox/translations/de.json
@@ -41,7 +41,7 @@
       "description": "Kapitel eines Kreativ-Tonies sortieren.",
       "fields": {
         "entity_id": { "name": "Kreativ-Tonie", "description": "Die media_player-Entität des Ziel-Kreativ-Tonies." },
-        "sort_by": { "name": "Sortieren nach", "description": "Kapitel sortieren nach: Titel, Dateiname oder Datum." }
+        "sort_by": { "name": "Sortieren nach", "description": "Kapitel sortieren nach: Titel, Dateiname, Datum oder zufällig (in eine neue zufällige Reihenfolge mischen)." }
       }
     },
     "remove_chapter": {
@@ -138,6 +138,7 @@
   "entity": {
     "sensor": {
       "current_tonie": {"name": "Aktuelle Figur"},
+      "current_tonie_id": {"name": "Aktuelle Figur ID"},
       "account": {"name": "Konto"},
       "tonies": {"name": "Kreativ-Tonies"},
       "content_tonies": {"name": "Content Tonies"},
@@ -197,8 +198,7 @@
       "language": {
         "name": "Boxsprache",
         "state": {"de": "Deutsch", "en": "Englisch", "en-us": "Englisch (US)", "fr": "Französisch"}
-      },
-      "sort_select": {"name": "Kapitel sortieren"}
+      }
     },
     "switch": {
       "skipping": {"name": "Klappsen zum Überspringen"},
@@ -207,6 +207,7 @@
       "accelerometer": {"name": "Kippen & Klopfen"},
       "private": {"name": "Nur in diesem Haushalt abspielen"},
       "live": {"name": "Live-Funktion"},
+      "shuffle_on_swap": {"name": "Beim Wechsel mischen"},
       "lock_household": {"name": "Im Haushalt sperren"}
     },
     "button": {
@@ -215,6 +216,7 @@
       "sort_by_title": {"name": "Nach Titel sortieren"},
       "sort_by_filename": {"name": "Nach Dateiname sortieren"},
       "sort_by_date": {"name": "Nach Datum sortieren"},
+      "sort_by_random": {"name": "Kapitel mischen"},
       "refresh": {"name": "Aktualisieren"},
       "factory_reset": {"name": "Auf Werkseinstellungen zurücksetzen"},
       "remove_tune": {"name": "Tune entfernen"}
@@ -229,7 +231,8 @@
       "locked_household": {"name": "Im Haushalt gesperrt"},
       "transcoding_active": {"name": "Transkodierung aktiv"},
       "charging": {"name": "Wird geladen"},
-      "headphones_connected": {"name": "Verbunden"}
+      "headphones_connected": {"name": "Verbunden"},
+      "sleeptimer_active": {"name": "Schlaftimer aktiv"}
     }
   }
 }

--- a/custom_components/toniebox/translations/en.json
+++ b/custom_components/toniebox/translations/en.json
@@ -41,7 +41,7 @@
       "description": "Sort the chapters on a Creative Tonie.",
       "fields": {
         "entity_id": { "name": "Creative Tonie", "description": "The media_player entity of the target creative tonie." },
-        "sort_by": { "name": "Sort By", "description": "Sort chapters by: title, filename, or date." }
+        "sort_by": { "name": "Sort By", "description": "Sort chapters by: title, filename, date, or random (shuffle into a new random order)." }
       }
     },
     "remove_chapter": {
@@ -138,6 +138,7 @@
   "entity": {
     "sensor": {
       "current_tonie": {"name": "Current Figure"},
+      "current_tonie_id": {"name": "Current Figure ID"},
       "account": {"name": "Account"},
       "tonies": {"name": "Creative Tonies"},
       "content_tonies": {"name": "Content Tonies"},
@@ -197,8 +198,7 @@
       "language": {
         "name": "Box Language",
         "state": {"de": "German", "en": "English", "en-us": "English (US)", "fr": "French"}
-      },
-      "sort_select": {"name": "Sort Chapters"}
+      }
     },
     "switch": {
       "skipping": {"name": "Skip with Ear Press"},
@@ -207,6 +207,7 @@
       "accelerometer": {"name": "Tilt & Tap"},
       "private": {"name": "Play in This Household Only"},
       "live": {"name": "Live Mode"},
+      "shuffle_on_swap": {"name": "Shuffle on swap"},
       "lock_household": {"name": "Lock to Household"}
     },
     "button": {
@@ -215,6 +216,7 @@
       "sort_by_title": {"name": "Sort by Title"},
       "sort_by_filename": {"name": "Sort by Filename"},
       "sort_by_date": {"name": "Sort by Date"},
+      "sort_by_random": {"name": "Shuffle Chapters"},
       "refresh": {"name": "Refresh"},
       "factory_reset": {"name": "Factory Reset"},
       "remove_tune": {"name": "Remove Tune"}
@@ -229,7 +231,8 @@
       "locked_household": {"name": "Locked to Household"},
       "transcoding_active": {"name": "Transcoding Active"},
       "charging": {"name": "Charging"},
-      "headphones_connected": {"name": "Connected"}
+      "headphones_connected": {"name": "Connected"},
+      "sleeptimer_active": {"name": "Sleep Timer Active"}
     }
   }
 }

--- a/custom_components/toniebox/translations/es.json
+++ b/custom_components/toniebox/translations/es.json
@@ -49,7 +49,7 @@
         },
         "sort_by": {
           "name": "Ordenar por",
-          "description": "Ordenar capítulos por: título, nombre de archivo o fecha."
+          "description": "Ordenar capítulos por: título, nombre de archivo, fecha o aleatorio (mezclar en un nuevo orden aleatorio)."
         }
       }
     },
@@ -209,6 +209,9 @@
       "current_tonie": {
         "name": "Figura actual"
       },
+      "current_tonie_id": {
+        "name": "ID de figura actual"
+      },
       "battery": {"name": "Batería actual"},
       "battery_status": {"name": "Estado de batería actual"},
       "last_battery": {"name": "Última batería"},
@@ -223,7 +226,8 @@
     },
     "binary_sensor": {
       "charging": {"name": "Cargando"},
-      "headphones_connected": {"name": "Conectados"}
+      "headphones_connected": {"name": "Conectados"},
+      "sleeptimer_active": {"name": "Temporizador de apagado activo"}
     },
     "number": {
       "lightring_brightness": {
@@ -279,9 +283,6 @@
           "en-us": "Inglés (EE. UU.)",
           "fr": "Francés"
         }
-      },
-      "sort_select": {
-        "name": "Ordenar capítulos"
       }
     },
     "switch": {
@@ -302,6 +303,9 @@
       },
       "live": {
         "name": "Modo en vivo"
+      },
+      "shuffle_on_swap": {
+        "name": "Mezclar al cambiar"
       }
     }
   }

--- a/custom_components/toniebox/translations/fr.json
+++ b/custom_components/toniebox/translations/fr.json
@@ -49,7 +49,7 @@
         },
         "sort_by": {
           "name": "Trier par",
-          "description": "Trier les chapitres par : titre, nom de fichier ou date."
+          "description": "Trier les chapitres par : titre, nom de fichier, date ou aléatoire (mélanger dans un nouvel ordre aléatoire)."
         }
       }
     },
@@ -209,6 +209,9 @@
       "current_tonie": {
         "name": "Figurine actuelle"
       },
+      "current_tonie_id": {
+        "name": "ID figurine actuelle"
+      },
       "battery": {"name": "Batterie actuelle"},
       "battery_status": {"name": "État actuel de la batterie"},
       "last_battery": {"name": "Dernière batterie"},
@@ -223,7 +226,8 @@
     },
     "binary_sensor": {
       "charging": {"name": "En charge"},
-      "headphones_connected": {"name": "Connecté"}
+      "headphones_connected": {"name": "Connecté"},
+      "sleeptimer_active": {"name": "Minuteur de veille actif"}
     },
     "number": {
       "lightring_brightness": {
@@ -279,9 +283,6 @@
           "en-us": "Anglais (É.-U.)",
           "fr": "Français"
         }
-      },
-      "sort_select": {
-        "name": "Trier les chapitres"
       }
     },
     "switch": {
@@ -302,6 +303,9 @@
       },
       "live": {
         "name": "Mode en direct"
+      },
+      "shuffle_on_swap": {
+        "name": "Mélanger au changement"
       }
     }
   }

--- a/custom_components/toniebox/translations/it.json
+++ b/custom_components/toniebox/translations/it.json
@@ -49,7 +49,7 @@
         },
         "sort_by": {
           "name": "Ordina per",
-          "description": "Ordina i capitoli per: titolo, nome file o data."
+          "description": "Ordina i capitoli per: titolo, nome file, data o casuale (rimescola in un nuovo ordine casuale)."
         }
       }
     },
@@ -209,6 +209,9 @@
       "current_tonie": {
         "name": "Figura attuale"
       },
+      "current_tonie_id": {
+        "name": "ID figura attuale"
+      },
       "battery": {"name": "Batteria attuale"},
       "battery_status": {"name": "Stato batteria attuale"},
       "last_battery": {"name": "Ultima batteria"},
@@ -223,7 +226,8 @@
     },
     "binary_sensor": {
       "charging": {"name": "In carica"},
-      "headphones_connected": {"name": "Collegato"}
+      "headphones_connected": {"name": "Collegato"},
+      "sleeptimer_active": {"name": "Timer di spegnimento attivo"}
     },
     "number": {
       "lightring_brightness": {
@@ -279,9 +283,6 @@
           "en-us": "Inglese (USA)",
           "fr": "Francese"
         }
-      },
-      "sort_select": {
-        "name": "Ordina capitoli"
       }
     },
     "switch": {
@@ -302,6 +303,9 @@
       },
       "live": {
         "name": "Modalità live"
+      },
+      "shuffle_on_swap": {
+        "name": "Mescola al cambio"
       }
     }
   }


### PR DESCRIPTION
## Summary

Incorporates the verified, useful parts of PR #30 (xylonm) directly onto `main`, since that branch predates our recent ICI fixes (#28/#29) and carries fork branding that can't be merged as-is. See the review on #30 for the full rationale.

- `playback/state` payload verified against a live account: `tonie` is a flat ID string, not an object — real-time current-Tonie detection now works reliably (#24).
- Live playback control on the Toniebox 2 (TNG) via ICI `app-control` topics: play/pause, next/previous chapter, volume, chapter browse/jump, and a new `toniebox.sleeptimer` service with a `sleeptimer_active` binary sensor.
- `sort_chapters` gains a `random` mode; new per-Creative-Tonie "shuffle on swap" switch that reshuffles a Tonie once a different one displaces it on a box (TNG real-time + REST poll, guarded against double-triggering). The old `sort_chapters` select entity is replaced by buttons (existing select becomes unavailable and can be deleted).
- GraphQL field-name fixes for content tonies/discs (`title`/`lock`/`languageName` instead of `name`/`locked`/`language`); the `myTonieboxes` placement query is dropped (no such field) since ICI is now the sole placement source — README calls out that this leaves classic (non-TNG) boxes without swap/placement detection.
- New `sensor.<toniebox>_current_tonie_id` exposing the raw Tonie ID for automations.

The existing ICI TLS fix (#29) and proactive auth-failure token refresh (`on_auth_failed`, #28) are untouched — the source PR's branch had reverted both; that revert is not carried over here.

Bump to 3.7.12.

## Test plan
- [x] `python3 -m py_compile` passes on all changed files
- [x] All translation/strings JSON files validated and load correctly
- [ ] Verify on a real Home Assistant instance with a TNG Toniebox: play/pause/skip/volume controls, sleep timer, chapter browsing, and shuffle-on-swap

---
_Generated by [Claude Code](https://claude.ai/code/session_016ieynC9Wo9bMCiVMa9U1GL)_